### PR TITLE
make gardener/dashboard/identity/dns-controller repository and image configurable

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -21,12 +21,31 @@ landscape:
   versions:
     gardener:
       <<: (( merge ))
+      repo: "https://github.com/gardener/gardener.git"
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.18.0" ))
+      apiserver:
+        <<: (( merge ))
+        image_repo: "eu.gcr.io/gardener-project/gardener/apiserver"
+        image_tag: (( valid( tag ) ? tag :~~ ))
+      controller_manager:
+        <<: (( merge ))
+        image_repo: "eu.gcr.io/gardener-project/gardener/controller-manager"
+        image_tag: (( valid( tag ) ? tag :~~ ))
     dashboard:
       <<: (( merge ))
+      repo: "https://github.com/gardener/dashboard.git"
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :"1.28.0" ))
+      image_tag: (( valid( tag ) ? tag :~~ ))
+    identity:
+      <<: (( merge ))
+      repo: (( dashboard.repo ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :( dashboard.tag || ~~ ) ))
+      branch: (( valid( commit ) ? ~~ :( dashboard.branch || ~~ ) ))
+      commit: (( dashboard.commit || ~~ ))
     dns_controller:
-      tag: "0.2.0-master"
+      <<: (( merge ))
+      image_tag: "0.2.0-master"
+      image_repo: "eu.gcr.io/gardener-project/dns-controller-manager"
   networks:
   iaas:
   etcd:

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -26,7 +26,6 @@ plugins:
 
 dashboard_git:
   <<: (( .landscape.versions.dashboard ))
-  repo: "https://github.com/gardener/dashboard.git"
   files:
     - "charts"
 
@@ -40,7 +39,9 @@ dashboard:
     hosts:
       - (( imports.identity.export.dashboard_dns ))
     image:
-      tag: (( .dashboard_git.tag || ~~ ))
+      repository: (( .dashboard_git.image_repo || ~~ ))
+      tag: (( .dashboard_git.image_tag || ~~ ))
+      pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
     oidc:
       issuerUrl: (( imports.identity.export.issuer_url ))
       ca: (( imports.identity.export.ca.crt ))

--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -51,7 +51,8 @@ providers:
 
 spec:
   <<: (( &temporary ))
-  version: (( .landscape.versions.dns_controller.tag ))
+  image_tag: (( .landscape.versions.dns_controller.image_tag ))
+  image_repo: (( .landscape.versions.dns_controller.image_repo ))
   namespace: "kube-system"
   identifier: (( "dns-controller_" landscape.name ))
   type: (( .landscape.dns.type ))

--- a/components/dns-controller/manifests/controller.yaml
+++ b/components/dns-controller/manifests/controller.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: dns-controller-manager
-        image: (( "eu.gcr.io/gardener-project/dns-controller-manager:" values.version ))
+        image: (( values.image_repo ":" values.image_tag ))
         imagePullPolicy: "Always"
         args:
         - (( "--controllers=" join( ",", values.controllers ) ))

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -61,7 +61,6 @@ kubectl_apply:
 
 gardener_git:
   <<: (( .landscape.versions.gardener ))
-  repo: "https://github.com/gardener/gardener.git"
   files:
     - "charts"
 
@@ -86,9 +85,9 @@ gardener:
         featureGates: {}
         groupPriorityMinimum: 10000
         image:
-          pullPolicy: (( defined(.gardener_git.tag) -and .gardener_git.tag == "latest" ? "Always" :"IfNotPresent" ))
-          repository: eu.gcr.io/gardener-project/gardener/apiserver
-          tag: (( .gardener_git.tag || ~~ ))
+          pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
+          repository: (( .gardener_git.apiserver.image_repo ))
+          tag: (( .gardener_git.apiserver.image_tag || ~~ ))
         insecureSkipTLSVerify: false
         replicaCount: 1
         resources:
@@ -165,9 +164,9 @@ gardener:
             hostedZoneID: (( .landscape.dns.hostedZoneID ))
         enabled: true
         image:
-          pullPolicy: (( defined(.gardener_git.tag) -and .gardener_git.tag == "latest" ? "Always" :"IfNotPresent" ))
-          repository: eu.gcr.io/gardener-project/gardener/controller-manager
-          tag: (( .gardener_git.tag || ~~ ))
+          pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
+          repository: (( .gardener_git.controller_manager.image_repo ))
+          tag: (( .gardener_git.controller_manager.image_tag || ~~ ))
         internalDomain:
           credentials: (( .landscape.dns.credentials ))
           domain: (( "internal." .landscape.clusters.[0].domain ))

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -22,8 +22,7 @@ plugins:
   - helm: identity
 
 identity_git:
-  <<: (( .landscape.versions.dashboard ))
-  repo: "https://github.com/gardener/dashboard.git"
+  <<: (( .landscape.versions.identity ))
   files:
     - "charts"
 
@@ -78,6 +77,10 @@ identity:
   name: "identity"
   namespace: (( .landscape.namespace ))
   values:
+    image:
+      repository: (( .identity_git.image_repo || ~~ ))
+      tag: (( .identity_git.image_tag || ~~ ))
+      pullPolicy: (( defined( tag ) -and tag == "latest" ? "Always" :"IfNotPresent" ))
     dashboardClientSecret: (( .state.dashboardClientSecret.value ))
     kubectlClientSecret: (( .state.kubectlClientSecret.value ))
     dashboardOrigins:


### PR DESCRIPTION
The `versions` node is now more powerful and allows changing the git repository
as well as the image repository and tag (independent of the git repo).
It is still completely optional.

The structure is as follows:

```yaml
landscape:
  ...
  versions:
    gardener:
      repo: <git repo url>
      tag: <tag to checkout - overwrites branch/commit>
      branch: <branch to checkout - overwrites commit>
      commit: <commit to checkout>
      apiserver:
        image_repo: <image repo url>
        image_tag: <image tag>
      controller_manager:
        image_repo: <see above>
        image_tag: <see above>
    dashboard:
      repo: <see above>
      tag: <see above>
      branch: <see above>
      commit: <see above>
      image_repo: <see above>
      image_tag: <see above>
    identity:
      repo: <see above>
      tag: <see above>
      branch: <see above>
      commit: <see above>
      image_repo: <see above>
      image_tag: <see above>
    dns_controller:
      image_tag: <see above>
      image_repo: <see above>
```

For each repo, only one of tag/branch/commit should be specified, otherwise some of them will be ignored (see above).

When overwriting some of these values, keep in mind that this project is tailored towards a specific version and might not work if that version is changed.

It is strongly advised to not overwrite any of these values, unless you know exactly what you are doing.