### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Use the following yaml keys depending on your provider (excerpts):
 
 | AWS  | GCP | Azure |
 |:--------------|:--------------|:--------------|
-|<pre>    credentials: <br/>      region: ...<br/>      accessKeyID: ...<br/>      secretAccessKey: ... </pre> |<pre>    credentials: <br/>      serviceaccount.json: &#124;<br/>      {</br>        "type": "...",</br>        "project_id": "...",</br>        ...</br>      }</pre>|<pre>    credentials:<br/>      clientID: ...<br/>      clientSecret: ...<br/>      subscriptionID: ...<br/>      tenantID: ...</pre>|
+|<pre>    credentials: <br/>      accessKeyID: ...<br/>      secretAccessKey: ... </pre> |<pre>    credentials: <br/>      serviceaccount.json: &#124;<br/>      {</br>        "type": "...",</br>        "project_id": "...",</br>        ...</br>      }</pre>|<pre>    credentials:<br/>      clientID: ...<br/>      clientSecret: ...<br/>      subscriptionID: ...<br/>      tenantID: ...</pre>|
 
 
 

--- a/acre.yaml
+++ b/acre.yaml
@@ -49,6 +49,10 @@ landscape:
       image_repo: "eu.gcr.io/gardener-project/dns-controller-manager"
   iaas:
   etcd:
+    backup:
+      type: (( .backup_type_mapping[iaas.type] ))
+      region: (( iaas.region ))
+      credentials: (( iaas.credentials ))
   identity:
   dns:
     type: (( .dns_type_mapping[iaas.type] ))
@@ -60,3 +64,9 @@ dns_type_mapping:
   gcp: google-clouddns
   aws: aws-route53
   azure: azure-dns
+
+backup_type_mapping:
+  <<: (( &temporary ))
+  gcp: gcs
+  aws: s3
+  azure: abs

--- a/acre.yaml
+++ b/acre.yaml
@@ -16,8 +16,10 @@ landscape:
   name: (( error("landscape name required") ))
   domain:
   namespace: garden
-  cluster: (( &local(~~) ))
-  clusters: (( defined(landscape.cluster) ? [ landscape.cluster ] :error("no cluster definition found") ))
+  cluster:
+    kubeconfig: ./kubeconfig
+    networks: ~
+  clusters: (( valid(landscape.cluster.networks) ? [ landscape.cluster ] :error("no cluster definition found") ))
   components: []
   versions:
     gardener:

--- a/acre.yaml
+++ b/acre.yaml
@@ -51,4 +51,12 @@ landscape:
   etcd:
   identity:
   dns:
+    type: (( .dns_type_mapping[iaas.type] ))
+    credentials: (( iaas.credentials ))
   profiles: (( [] ))
+
+dns_type_mapping:
+  <<: (( &temporary ))
+  gcp: google-clouddns
+  aws: aws-route53
+  azure: azure-dns

--- a/acre.yaml
+++ b/acre.yaml
@@ -19,7 +19,7 @@ landscape:
   cluster:
     kubeconfig: ./kubeconfig
     networks: ~
-  clusters: (( valid(landscape.cluster.networks) ? [ landscape.cluster ] :error("no cluster definition found") ))
+  clusters: (( valid(landscape.cluster.networks) ? [ landscape.cluster ] :error("no cluster networks definition found") ))
   components: []
   versions:
     gardener:
@@ -75,3 +75,70 @@ backup_type_mapping:
   gcp: gcs
   aws: s3
   azure: abs
+
+validation:
+  <<: (( &temporary ))
+  is_in: (( |e,l|-> [contains(l, e), "valid", "invalid value '" e "'"] ))
+  types:
+    iaas:
+      gcp: 
+        - mapfield
+        - serviceaccount.json
+      aws:
+        - and
+        - - mapfield
+          - accessKeyID
+        - - mapfield
+          - secretAccessKey
+      azure:
+        - and
+        - - mapfield
+          - clientID
+        - - mapfield
+          - clientSecret
+        - - mapfield
+          - subscriptionID
+        - - mapfield
+          - tenantID
+    etcd_backup:
+      gcs: (( iaas.gcp ))
+      s3: (( iaas.aws ))
+      abs: (( iaas.azure ))
+    dns:
+      google-clouddns: (( iaas.gcp ))
+      aws-route53: (( iaas.aws ))
+      azure-dns: (( iaas.azure ))
+  landscape_name: (( validate( landscape.name, "dnslabel" ) ))
+  domain: (( validate( landscape.domain, "dnsdomain" ) ))
+  cidrs: (( validate( landscape.clusters[0].networks, ["mapfield", "nodes", "cidr"], ["mapfield", "pods", "cidr"], ["mapfield", "services", "cidr"] ) ))
+  iaas_type: (( validate( landscape.iaas.type, [is_in, keys( types.iaas )] ) ))
+  iaas_creds: (( validate( landscape.iaas.credentials, types.iaas[landscape.iaas.type] ) ))
+  etcd_backup_type: (( validate( landscape.etcd.backup.type, [is_in, keys( types.etcd_backup )] ) ))
+  etcd_backup_creds: (( validate( landscape.etcd.backup.credentials, types.etcd_backup[landscape.etcd.backup.type] ) ))
+  azure_resource_group: (( landscape.etcd.backup.type == "abs" ? validate( landscape.etcd.backup, ["mapfield", "resourceGroup"] ) :~ ))
+  dns_type: (( validate( landscape.dns.type, [is_in, keys( types.dns )] ) ))
+  dns_creds: (( validate( landscape.dns.credentials, types.dns[landscape.dns.type] ) ))
+  identity:
+    userspec:
+      - and
+      - - mapfield
+        - email
+        - - match
+          - "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*@[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$"
+      - - mapfield
+        - username
+      - - or
+        - - mapfield
+          - password
+        - - mapfield
+          - hash
+    connectorspec:
+      - and
+      - - mapfield
+        - type
+      - - mapfield
+        - id
+      - - mapfield
+        - name
+    identityspec: (( |id|-> [valid( id.users || id.connectors ), "valid", "identity config needs to contain either 'users' or 'connectors' (or both)"] ))
+    validator: (( validate( landscape.identity, identityspec, ["optionalfield", "users", ["list", identity.userspec]], ["optionalfield", "connectors", ["list", identity.connectorspec]] ) ))

--- a/acre.yaml
+++ b/acre.yaml
@@ -14,6 +14,7 @@
 
 landscape:
   name: (( error("landscape name required") ))
+  domain:
   namespace: garden
   cluster: (( &local(~~) ))
   clusters: (( defined(landscape.cluster) ? [ landscape.cluster ] :error("no cluster definition found") ))
@@ -46,7 +47,6 @@ landscape:
       <<: (( merge ))
       image_tag: "0.4.0-master"
       image_repo: "eu.gcr.io/gardener-project/dns-controller-manager"
-  networks:
   iaas:
   etcd:
   identity:

--- a/acre.yaml
+++ b/acre.yaml
@@ -51,12 +51,15 @@ landscape:
       image_repo: "eu.gcr.io/gardener-project/dns-controller-manager"
   iaas:
   etcd:
+    <<: (( merge ))
     backup:
+      <<: (( merge ))
       type: (( .backup_type_mapping[iaas.type] ))
       region: (( iaas.region ))
       credentials: (( iaas.credentials ))
   identity:
   dns:
+    <<: (( merge ))
     type: (( .dns_type_mapping[iaas.type] ))
     credentials: (( iaas.credentials ))
   profiles: (( [] ))

--- a/acre.yaml.example
+++ b/acre.yaml.example
@@ -1,17 +1,16 @@
 landscape:
   name: my-gardener
+  domain: prefix.mydomain.org
 
   cluster:
-    kubeconfig: ./kubeconfig
-    domain: prefix.mydomain.org
-    iaas: <gcp/aws/azure>
-
-  networks:
-    nodes: <node CIDR>
-    pods: <pod CIDR>
-    services: <service CIDR>
+#    kubeconfig: ./kubeconfig # optional
+    networks:
+      nodes: <node CIDR>
+      pods: <pod CIDR>
+      services: <service CIDR>
 
   iaas:
+    type: <gcp/aws/azure>
     region: europe-west1
     zones:
       - europe-west1-b
@@ -20,17 +19,15 @@ landscape:
     credentials:
       # your credentials here
 
-  etcd:
-    backup:
-      type: <gcs/s3/abs>
-      region: europe-west1
-      credentials:
-        # your credentials here
+#  etcd: # optional
+#    backup:
+#      type: <gcs/s3/abs>
+#      region: (( iaas.region ))
+#      credentials: (( iaas.credentials ))
 
-  dns:
-    type: <google-clouddns/aws-route53/azure-dns>
-    credentials:
-      # your credentials here
+#  dns: # optional
+#    type: <google-clouddns/aws-route53/azure-dns>
+#    credentials: (( iaas.credentials ))
 
   identity:
     users:

--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -60,7 +60,7 @@ spec:
   namespace: "kube-system"
   identifier: (( "setup.gardener.cloud/" landscape.name ))
   type: (( .landscape.dns.type ))
-  domain: (( .landscape.clusters.[0].domain ))
+  domain: (( .landscape.domain ))
   secret_name: (( settings.naming "-dns-controller-manager-" provider.name ))
   dns_rbac_name: (( settings.naming "-dns-controller-manager" ))
   dns-class: (( settings.dns-class ))

--- a/components/etcd/backupinfra/deployment.yaml
+++ b/components/etcd/backupinfra/deployment.yaml
@@ -16,10 +16,9 @@ landscape: (( &temporary ))
 
 temp:
   <<: (( &temporary ))
-  type: (( landscape.etcd.backup.type ))
-  addon: (( read(dir "/tfvars.yaml") ))
-  dir: (( __ctx.DIR "/provider/" type ))
   config: (( landscape.etcd.backup ))
+  addon: (( read(dir "/tfvars.yaml") ))
+  dir: (( __ctx.DIR "/provider/" config.type ))
 
 plugins:
   - terraform

--- a/components/etcd/backupinfra/provider/abs/tfvars.yaml
+++ b/components/etcd/backupinfra/provider/abs/tfvars.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 CLIENT_ID: (( config.credentials.clientID ))
 CLIENT_SECRET: (( config.credentials.clientSecret ))
 TENANT_ID: (( config.credentials.tenantID ))

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -19,10 +19,9 @@ utilities: (( &temporary ))
 
 temp:
   <<: (( &temporary ))
-  type: (( landscape.etcd.backup.type ))
+  config: (( landscape.etcd.backup ))
   addon: (( read(dir "/provider.yaml") ))
-  dir: (( __ctx.DIR "/provider/" type ))
-  credentials: (( landscape.etcd.backup.credentials ))
+  dir: (( __ctx.DIR "/provider/" config.type ))
 
 plugins:
   - helm:
@@ -85,7 +84,7 @@ etcd:
         schedule: "0 */24 * * *" # cron standard schedule
         maxBackups: 7 # Maximum number of backups to keep (may change in future)
         storageProvider: (( spec.providertypes.[landscape.etcd.backup.type] ))  # Abs,Gcs,S3,Swift empty means no backup,
-        secretData: (( sum[temp.credentials|{}|c,k,v|->c {k=base64(v)}] ))
+        secretData: (( sum[temp.config.credentials|{}|c,k,v|->c {k=base64(v)}] ))
         storageContainer: (( imports.backupinfra.export.bucketname ))
         env: (( temp.addon.env ))
         volumeMounts: (( temp.addon.volumeMounts ))

--- a/components/etcd/cluster/provider/s3/provider.yaml
+++ b/components/etcd/cluster/provider/s3/provider.yaml
@@ -14,10 +14,10 @@
 
 env:
   - name: "AWS_REGION"
-    value: (( credentials.region ))
+    value: (( config.region ))
   - name: "AWS_ACCESS_KEY_ID"
-    value: (( credentials.accessKeyID ))
+    value: (( config.credentials.accessKeyID ))
   - name: "AWS_SECRET_ACCESS_KEY"
-    value: (( credentials.secretAccessKey ))
+    value: (( config.credentials.secretAccessKey ))
 
 volumeMounts: []

--- a/components/gardencontent/coreproject/deployment.yaml
+++ b/components/gardencontent/coreproject/deployment.yaml
@@ -29,7 +29,7 @@ shoot-check:
 values:
   projectname: core
   namespace: garden-core
-  secretname: (( "core-" landscape.clusters.[0].iaas ))
+  secretname: (( "core-" landscape.iaas.type ))
 
 core:
   kubeconfig: (( imports.kube_apiserver.export.kubeconfig ))

--- a/components/gardencontent/initialseed/deployment.yaml
+++ b/components/gardencontent/initialseed/deployment.yaml
@@ -33,7 +33,7 @@ cleanup:
   namespace: (( landscape.namespace ))
 
 providerconfig:
-  name: (( landscape.clusters.[0].iaas ))
+  name: (( landscape.iaas.type ))
   namespace: (( landscape.namespace ))
   dns:
     type: (( landscape.dns.type ))

--- a/components/gardencontent/initialseed/deployment.yaml
+++ b/components/gardencontent/initialseed/deployment.yaml
@@ -45,7 +45,7 @@ providerconfig:
     zones: (( landscape.iaas.zones || ~~ ))
     ingressdomain: (( imports.ingress_dns.export.ingress_domain ))
     kubeconfig: (( read(env.ROOTDIR "/" .cleanup.kubeconfig, "text") ))
-    networks: (( landscape.networks ))
+    networks: (( landscape.clusters.[0].networks ))
   secretname: (( name "-seed" ))
 
 kubectl:

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -176,7 +176,7 @@ gardener:
                 key: (( .state.gardener_controller_manager.value.key ))
         defaultDomains:
           - credentials: (( *.dns_credentials.[provider] ))
-            domain: (( "shoot." .landscape.clusters.[0].domain ))
+            domain: (( "shoot." .landscape.domain ))
             provider: (( .landscape.dns.type ))
         enabled: true
         image:
@@ -185,7 +185,7 @@ gardener:
           tag: (( .gardener_git.controller_manager.image_tag || ~~ ))
         internalDomain:
           credentials: (( *.dns_credentials.[provider] ))
-          domain: (( "internal." .landscape.clusters.[0].domain ))
+          domain: (( "internal." .landscape.domain ))
           provider: (( .landscape.dns.type ))
         replicaCount: 1
         resources:
@@ -198,5 +198,5 @@ gardener:
         serviceAccountName: gardener-controller-manager
       deployment:
         virtualGarden:
-          clusterIP: (( min_ip(.landscape.networks.services) + 20 ))
+          clusterIP: (( min_ip(.landscape.clusters.[0].networks.services) + 20 ))
           enabled: true

--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -20,7 +20,7 @@ plugins:
   - helm: ingresscontroller
 
 settings:
-  ingress_domain: (( "ingress." landscape.clusters.[0].domain ))
+  ingress_domain: (( "ingress." landscape.domain ))
 
 ingresscontroller:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))

--- a/merge_acre.yaml
+++ b/merge_acre.yaml
@@ -1,0 +1,25 @@
+# This file can be used to transform an old acre.yaml (before release 1.0.0) to a new acre.yaml.
+# Requirements: spiff++ v1.3.0 -> https://github.com/mandelsoft/spiff/releases/tag/v1.3.0
+# Usage:
+#   1. Rename your acre.yaml to acre_old.yaml (so you don't lose it in case something fails)
+#   2. Execute the command 'spiff merge ./merge_acre.yaml ../acre_old.yaml > ../acre.yaml' from within your 'crop' folder
+
+landscape:
+  name:
+  domain: (( stub( landscape.cluster.domain ) ))
+
+  cluster:
+    networks: (( stub( landscape.networks ) ))
+    kubeconfig: (( merge none // match( "^(\\./)?kubeconfig$", stub() ) == [] ? stub() :~~ ))
+
+  iaas:
+    type: (( stub( landscape.cluster.iaas ) ))
+    <<: (( merge ))
+
+  etcd: (( ~~ ))
+
+  dns: (( ~~ ))
+
+  versions: (( ~~ ))
+
+  identity:


### PR DESCRIPTION
This is about structuring and cleaning up the acre.yaml.

The following things have changed:
- `landscape.cluster.domain` is now `landscape.domain` and `landscape.networks` is now `landscape.cluster.networks`. The idea of the `cluster` node is to contain the properties of the base cluster. This includes the network CIDRs, but it doesn't include the domain, as it can be chosen and is completely independent from the base cluster.

- `landscape.cluster.iaas` is now `landscape.iaas.type`. Same reasoning as above - the value is about the infrastructure handled by the initial seed and while it might make life easier to align this with the base cluster's infrastructure, it is not necessarily related.

- `landscape.dns` is now optional. If not given, the DNS provider belonging to the `iaas.type` infrastructure is chosen and the credentials are also copied from the `iaas` block. 

- `landscape.etcd` is now optional. If not given it will derive the values from the `iaas` block, similar to the `dns` block. Note that this is not true for Azure - there a `landscape.etcd.backup.resourceGroup` value is needed which cannot be derived. However, if only this value is given, the missing backup parameters will still be derived from the `iaas` block.

- `landscape.cluster.kubeconfig` is now optional. The kubeconfig file will probably almost always be located in the landscape folder, so `./kubeconfig` has been set as a default value.

- AWS credentials don't need the `region` anymore. That was a relic from an earlier version.


So, a minimalistic acre.yaml could now look like this:
```yaml
landscape:
  name: my-gardener
  domain: my-gardener.my-domain.org
  cluster:
    networks:
      nodes: 10.234.0.0/19
      pods: 10.235.0.0/17
      services: 10.235.128.0/17
  iaas:
    type: aws
    region: eu-west-1
    zones:
      - eu-west-1a
      - eu-west-1b
      - eu-west-1c
    credentials:
      accessKeyID: ...
      secretAccessKey: ...
  identity:
    users:
    - email: admin@example.com
      username: Admin
      password: "SuperSecretPassword123"
```

If you have an `acre.yaml` in the old format, you can transform it into the new format manually or by using [spiff++](https://github.com/mandelsoft/spiff/releases/tag/v1.3.0):
1. Rename your `acre.yaml` to `acre_old.yaml`
2. `cd` into your `crop` folder and execute `spiff merge ./merge_acre.yaml ../acre_old.yaml > ../acre.yaml`


Another new feature is validation of the `acre.yaml` file. Any call to `sow` will verify that the needed fields are there, and fail if not. For most fields, only their existence is checked, though, and not their content.