### PR TITLE
Qualified branch and commit keys for gardener extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -47,63 +47,63 @@ landscape:
       extensions:
         dns-external:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :( .landscape.versions.dns-controller.tag || "0.5.5" ) ))
-          image_tag: (( versions.dns-controller.tag || "0.5.5" ))
+          tag: (( valid( dns-external.branch ) -or valid( dns-external.commit ) ? ~~ :( .landscape.versions.dns-controller.tag || "0.5.5" ) ))
+          image_tag: (( .landscape.versions.dns-controller.tag || "0.5.5" ))
           image_repo: (( ~~ ))
           repo: https://github.com/gardener/external-dns-management.git
           chart_path: charts/external-dns-management
         os-coreos:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( os-coreos.branch ) -or valid( os-coreos.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/os-coreos/charts/os-coreos
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         os-coreos-alicloud:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( os-coreos-alicloud.branch ) -or valid( os-coreos-alicloud.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/os-coreos-alicloud/charts/os-coreos-alicloud
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         os-suse-jeos:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( os-suse-jeos.branch ) -or valid( os-suse-jeos.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/os-suse-jeos/charts/os-suse-jeos
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         provider-alicloud:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( provider-alicloud.branch ) -or valid( provider-alicloud.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/provider-alicloud/charts/provider-alicloud
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         provider-aws:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( provider-aws.branch ) -or valid( provider-aws.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/provider-aws/charts/provider-aws
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         provider-gcp:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( provider-gcp.branch ) -or valid( provider-gcp.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/provider-gcp/charts/provider-gcp
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         provider-azure:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( provider-azure.branch ) -or valid( provider-azure.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/provider-azure/charts/provider-azure
           image_tag: (( valid( tag ) ? tag :~~ ))
           image_repo: (( ~~ ))
         provider-openstack:
           <<: (( merge ))
-          tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.6" ))
+          tag: (( valid( provider-openstack.branch ) -or valid( provider-openstack.commit ) ? ~~ :"0.6.6" ))
           repo: https://github.com/gardener/gardener-extensions.git
           chart_path: controllers/provider-openstack/charts/provider-openstack
           image_tag: (( valid( tag ) ? tag :~~ ))


### PR DESCRIPTION
**What this PR does / why we need it**:
If you specify a branch or commit for gardener, it must not be used by the extensions in the acre.yaml config subtree.
