### PR TITLE
allow configuration of dashboard values (gitHub and frontendConfig) in acre.yaml

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -133,8 +133,9 @@ landscape:
       type: (( .backup_type_mapping[iaas[0].type] ))
       region: (( iaas[0].region ))
       credentials: (( iaas[0].credentials ))
+  dashboard: (( ~~ ))
   identity:
-  gardener:
+  gardener: (( ~~ ))
   dns:
     <<: (( merge ))
     type: (( .dns_type_mapping[iaas[0].type] ))
@@ -296,6 +297,8 @@ validation:
             - networks
             - (( validation.networks ))
     cloudprofile: (( &template( return_true ) ))
+  dashboard_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
+  gardener_validator: ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]]
   networks:
     - and
     - ["mapfield", "nodes", "cidr"]
@@ -330,6 +333,10 @@ validation:
     hostedZoneIDs: (( validate( landscape.dns, ["optionalfield", "hostedZoneIDs", ["map", ["valueset", ["include", "exclude"]], "list"]] ) ))
     provider_config: (( validate( landscape.dns, types.dns[landscape.dns.type].config ) ))
     credentials: (( validate( landscape.dns, ["mapfield", "credentials", types.dns[landscape.dns.type].credentials] ) ))
+  ##### landscape.gardener
+  gardener: (( defined( landscape.gardener ) ? validate( landscape.gardener, validation.gardener_validator ) :~~ ))
+  ##### landscape.dashboard
+  dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator ) :~~ ))
   ##### landscape.identity TODO
   identity:
     userspec:

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -52,7 +52,9 @@ dashboard:
       crt: (( imports.identity.export.server.crt ))
       key: (( imports.identity.export.server.key ))
     kubeconfig: (( asyaml(imports.kube_apiserver.export.kubeconfig) ))
+    gitHub: (( .landscape.dashboard.gitHub || ~~ ))
     frontendConfig:
+      <<: (( .landscape.dashboard.frontendConfig || ~ ))
       seedCandidateDeterminationStrategy: (( .imports.gardener_virtual.export.gardener.seedCandidateDeterminationStrategy ))
 
 util:

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -19,7 +19,7 @@ utilities: (( &temporary ))
 env: (( &temporary ))
 
 settings:
-  
+  seedCandidateDeterminationStrategy: (( .landscape.gardener.seedCandidateDeterminationStrategy || "SameRegion" ))
 
 spec:
   <<: (( &temporary ))
@@ -116,15 +116,22 @@ gardener:
   source: "gardener_git/repo/charts/gardener/charts/application"
   name: "gardener"
   namespace: "garden"
-  admissionControlYaml: "apiVersion: apiserver.k8s.io/v1alpha1\nkind: AdmissionConfiguration\nplugins:\n  - name: ShootSeedManager\n    configuration:\n      apiVersion: seedmanager.admission.config.gardener.cloud/v1alpha1\n      kind: Configuration\n      candidateDeterminationStrategy: "
-  admissionControlValue: (( .landscape.gardener.seedCandidateDeterminationStrategy || "SameRegion" ))
+  admissionControlYaml:
+    apiVersion: apiserver.k8s.io/v1alpha1
+    kind: AdmissionConfiguration
+    plugins:
+      - name: ShootSeedManager
+        configuration:
+          apiVersion: seedmanager.admission.config.gardener.cloud/v1alpha1
+          kind: Configuration
+          candidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
   values:
     global:
       apiserver:
         kubeconfig: dummy
         caBundle: (( .state.gardener_ca.value.cert ))
         enabled: true
-        admissionControlConfig: (( admissionControlYaml admissionControlValue ))
+        admissionControlConfig: (( asyaml( gardener.admissionControlYaml ) ))
         etcd:
           servers: (( join(",",.imports.etcd.exports.endpoints.main) ))
           useSidecar: false

--- a/components/gardener/virtual/export.yaml
+++ b/components/gardener/virtual/export.yaml
@@ -15,8 +15,9 @@
 ---
 gardener: (( &temporary ))
 gardener_git: (( &temporary ))
+settings: (( &temporary ))
 export:
   gardener:
-    seedCandidateDeterminationStrategy: (( .gardener.admissionControlValue ))
+    seedCandidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
     values: (( .gardener.values ))
   gardener_git: (( .gardener_git ))

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -1,0 +1,9 @@
+# Extended Configuration Options for 'landscape.dashboard'
+
+The `landscape.dashboard` node is entirely optional. There are basically two nodes in it that are evaluated:
+- `landscape.dashboard.frontendConfig`
+- `landscape.dashboard.gitHub`
+
+The contents of both nodes will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values. 
+
+Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -1,0 +1,3 @@
+# Extended Configuration Options for 'landscape.gardener'
+
+There is only one configuration option for `landscape.gardener` and that is `landscape.gardener.seedCandidateDeterminationStrategy`. The two possible values are `SameRegion` (default) and `MinimalDistance`. In the first case, shoots can only be created in regions where a seed exists and only those regions will show up in the dashboard. In the latter case, shoots can be created in any region listed in the cloudprofile and the geographically closest seed will be used.

--- a/docs/extended/index.md
+++ b/docs/extended/index.md
@@ -1,0 +1,7 @@
+# Overview of Extended Configuration Options
+
+This document links to all extended configuration documentations for a better overview.
+
+- [landscape.iaas](iaas.md)
+- [landscape.dashboard](dashboard.md)
+- [landscape.gardener](gardener.md)


### PR DESCRIPTION
+ add documentation for 'landscape.dashboard' and 'landscape.gardener' nodes in acre.yaml
+ rework creation of admissionControlConfig value in Gardener helm values

**Which issue(s) this PR fixes**:
https://github.com/gardener/garden-setup/issues/46