### PR TITLE
Support specifying letsencrypt private key for cert-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ landscape:
   <a href="#landscapecert-manager">cert-manager</a>:
     email:                                    # email for acme registration
     server: &lt;live|staging|self-signed|url&gt;    # which kind of certificates to use for the dashboard/identity ingress (defaults to `self-signed`)
+    privateKey:                               # optional existing user account's private key
 </pre>
 
 
@@ -316,6 +317,7 @@ You can then login into the dashboard using one of the specified email/password 
   cert-manager:
     email:                                   
     server: <live|staging|self-signed|url>
+    privateKey: # optional
 ```
 
 The setup deploys a [cert-manager](https://github.com/jetstack/cert-manager) to provide a certificate for the Gardener dashboard, which can be configured here. 
@@ -334,6 +336,7 @@ If set to anything else, it is assumed to be the URL of an ACME server and the s
 
 See the [extended configuration](docs/extended/cert-manager.md) for more configuration options.
 
+If the given email address is already registers at letsencrypt, you can specify the private key of the associated user account with `landscape.cert-manager.privateKey`.
 
 ## Uninstall Gardener
 

--- a/acre.yaml.example
+++ b/acre.yaml.example
@@ -57,3 +57,9 @@ landscape:
 #  cert-manager:
 #    email: "john.doe@mydomain.org"
 #    server: live
+#    ## optional existing user account's key
+#    #privateKey: |+
+#    # -----BEGIN RSA PRIVATE KEY-----
+#    # MII...
+#    # ...
+#    # -----END RSA PRIVATE KEY-----

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -10,6 +10,7 @@ settings:
   serviceAccountName: cert-manager
   self-signed: (( .caSpec.url == "self-signed" ))
   issuerName: (( .settings.self-signed ? "ca-issuer" :"acme-issuer" ))
+  issuerPrivateKey: (( .settings.self-signed -or (! valid( .landscape.cert-manager.privateKey ) ) ? "" :.landscape.cert-manager.privateKey ))
   caSecret: "self-signed-ca"
   ca:
     given: (( &temporary ( valid( .caSpec.ca.crt ) -and ( ( ! .settings.self-signed ) -or valid( .caSpec.ca.key ) ) ) )) # a given CA needs crt and key for self-signed mode
@@ -60,10 +61,22 @@ crds:
 
 issuer: (( .settings.self-signed ? *ca_issuer :*acme_issuer ))
 
+issuer-secret:
+  - <<: (( &template &temporary ))
+  - apiVersion: v1
+    kind: Secret
+    type: Opaque
+    metadata:
+      name: (( settings.issuerName "-secret" ))
+      namespace: (( .landscape.namespace ))
+    data:
+      tls.key: (( base64(settings.issuerPrivateKey) ))
+
 acme_issuer:
   <<: (( &template &temporary ))
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   manifests:
+    - <<: (( valid( .settings.issuerPrivateKey ) ? *issuer-secret :[] ))
     - apiVersion: certmanager.k8s.io/v1alpha1
       kind: Issuer
       metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
If you want to use shared user account of Let's Encrypt, you need to provide its private key.
An example at SAP is the usage of the user account `kubernetes_ops@sap.com` for avoid problems like

```
error creating new order: acme: urn:ietf:params:acme:error:rateLimited: Error creating new order :: too many certificates already issued for: ondemand.com
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Support specifying user account private key for cert-manager
```
