### PR TITLE
shoot-check plugin doesn't fail on 'the server doesn't have a resource type "shoots"'

### DIFF
--- a/plugins/shoot-check/plugin
+++ b/plugins/shoot-check/plugin
@@ -32,20 +32,15 @@ deploy() {
 # if a namespace is given, only look in that namespace for shoots
 # if one or more seeds are given, filter for shoots that use one of these seeds
 delete() {
-    if [ -n ${namespace:-""} ]; then
-        nsmod="-n $namespace"
-    else
-        nsmod="--all-namespaces"
-    fi
     shoots=
     seed=
     if [ ${#seeds[@]} -eq 0 ]; then
         # if no seeds are specified
-        shoots=$(kubectl get shoots $nsmod --no-headers 2> "$dir/error_log.txt") || fail $(cat "$dir/error_log.txt") # don't show "No resources found." message
+        shoots=$(get_shoots ${namespace:-""})
     else
         # if seeds are specified
         for s in ${seeds[@]}; do
-            shoots=$(kubectl get shoots $nsmod --field-selector spec.cloud.seed=$s 2> "$dir/error_log.txt") || fail $(cat "$dir/error_log.txt")
+            shoots=$(get_shoots ${namespace:-""} "$s")
             if [ -n "$shoots" ]; then
                 seed=$s
                 break
@@ -68,6 +63,29 @@ delete() {
     else
         info "No conflicting shoots found."
     fi
+}
+
+get_shoots() {
+    namespace=${1:-""}
+    seed=${2:-""}
+
+    if [ -n "$namespace" ]; then
+        nsmod="-n $namespace"
+    else
+        nsmod="--all-namespaces"
+    fi
+    if [ -n "$seed" ]; then
+        smod="--field-selector spec.cloud.seed=$seed"
+    else
+        smod="--no-headers"
+    fi
+    if ! shoots=$(kubectl get shoots $nsmod $smod 2> "$dir/error_log.txt"); then
+        err=$(cat "$dir/error_log.txt")
+        if [ "$err" != "error: the server doesn't have a resource type \"shoots\"" ]; then
+            fail "$err"
+        fi
+    fi
+    echo "$shoots"
 }
 
 case "$1" in


### PR DESCRIPTION
**What this PR does / why we need it**:
When the `gardener/runtime` component fails on deployment, its deletion would fail too because the `kubectl get shoots` command from the shoot-check plugin failed due to `shoot` not being a known resource. This fixes it.

**Which issue(s) this PR fixes**:
#57 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The shoot-check plugin will now ignore the error message `the server doesn't have a resource type "shoots"` and continue the deletion.
```
