### PR TITLE
remove leftover state folder after deleting `gardener/extensions` component

### DIFF
--- a/components/gardener/extensions/action
+++ b/components/gardener/extensions/action
@@ -1,0 +1,22 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#source "$SOWLIB/k8s"
+
+cleanup()
+{
+  if [ "$1" = "cleanup" ]; then
+    rm -rf "$STATEDIR"
+  fi
+}

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -11,6 +11,7 @@ component:
 
   plugins:
     - <<: (( sum[.extensions|[]|s,n,v|-> s [{ "-echo" = "--------------------------------------------------" }, { "-echo" = "checking out charts for extension '" n "'" }, { "git" = "extensions." n }]] ))
+    - cleanup
 
 # input for git plugin
 extensions: (( sum[.deployment.extensions|{}|s,n|-> s { n = *spec_template }] ))


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
#50 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
After deleting the `gardener/extensions` component, the corresponding state folder is now properly deleted and `sow order -A` doesn't show it as partially deployed anymore.
```
