### PR TITLE
Add integration test support for specific base clusters in PR's

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,7 +22,9 @@ garden-setup:
           interval: '5m'
     pull_request_integration:
       traits:
-        pull-request: ~
+        pull-request:
+          disable-status-report:
+          - prepare-test
         scheduling:
           suppress_parallel_execution: true
         version:
@@ -30,10 +32,19 @@ garden-setup:
             'inject-commit-hash'
           inject_effective_version: true
       steps:
+        prepare-test:
+          image: eu.gcr.io/gardener-project/gardener/testmachinery/base-step:latest
+          output_dir: out
+          execute:
+          - ./it-prepare.py
         integration-test:
           image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
+          depends:
+          - prepare-test
+          inputs:
+            OUT_PATH: out_path
           execute:
-          - ./pr_labels.py
+          - ./tm-test
           - --tm-chart=default
           - --landscape=test
           - --tm-landscape=external

--- a/.ci/tm-test
+++ b/.ci/tm-test
@@ -69,6 +69,11 @@ VERSION=$(git rev-parse HEAD)
 popd
 GARDENER_VERSION="$(cat $SOURCE_PATH/GARDENER_VERSION)"
 
+# Add configuration if a configuration file exists
+if [[ -f $OUT_PATH/config.yaml ]]; then
+    ARGUMENTS="$ARGUMENTS --values=$OUT_PATH/config.yaml"
+fi
+
 echo "Testmachinery config name: ${TM_CONFIG_NAME}"
 echo "Testmachinery landscape: ${TM_LANDSCAPE}"
 echo "Arguments: ${ARGUMENTS}"

--- a/test/acre.yaml
+++ b/test/acre.yaml
@@ -1,5 +1,7 @@
 # GARDENER_PREFIX: (default "test") use a a unique identifier for dns and gardener name
 
+# BASE_CLOUDPROVIDER: cloudprovider for the base cluster
+
 # Specify the deployed gardener version by using the GARDENER_VERSION or GARDENER_IMAGE_TAG and GARDENER_COMMIT
 # GARDENER_VERSION: use a specific gardener version/tag
 
@@ -24,6 +26,43 @@ k8sVersions:
   kubernetes:
     versions:
     - (( env( "K8S_VERSION" ) || "1.14.3" ))
+
+base_cluster_configs:
+  gcp:
+    type: gcp
+    region: europe-west1
+    zones:
+      - (( region "-b"))
+      - (( region "-c"))
+      - (( region "-d"))
+    credentials:
+      <<: (( .gcp-credentials ))
+    profile:
+      gcp:
+        constraints:
+          <<: (( .k8sVersions ))
+  aws:
+    type: aws
+    region: eu-west-1
+    zones:
+      - (( region "a"))
+      - (( region "b"))
+      - (( region "c"))
+    credentials:
+      <<: (( .aws-credentials ))
+    profile:
+      aws:
+        constraints:
+          <<: (( .k8sVersions ))
+  azure:
+    type: azure
+    region: westeurope
+    credentials:
+      <<: (( .azure-credentials ))
+    profile:
+      azure:
+        constraints:
+          <<: (( .k8sVersions ))
 
 
 ############################################################################
@@ -52,8 +91,11 @@ landscape:
       services: 10.31.240.0/20
 
   iaas:
-  - name: gcp
+  - name: base
     mode: seed
+    <<: (( .base_cluster_configs[env( "BASE_CLOUDPROVIDER" )] || .base_cluster_configs.gcp ))
+  - name: gcp
+    mode: cloudprofile
     type: gcp
     region: europe-west1
     zones:
@@ -90,6 +132,14 @@ landscape:
       azure:
         constraints:
           <<: (( .k8sVersions ))
+
+  dns:
+    type: google-clouddns
+    credentials: (( .gcp-credentials ))
+
+  etcd:
+    backup:
+      resourceGroup: (( .landscape.name ))
 
   identity:
     users:

--- a/test/scripts/delete
+++ b/test/scripts/delete
@@ -15,4 +15,4 @@ cp -R $TM_SHARED_PATH/setup/* .
 sow order -A
 sow delete -A
 
-rm $TM_KUBECONFIG_PATH/gardener.config
+rm -f $TM_KUBECONFIG_PATH/gardener.config

--- a/test/testruns/default/templates/_aws-shoot.tpl
+++ b/test/testruns/default/templates/_aws-shoot.tpl
@@ -16,7 +16,7 @@
         value: {{ .Values.shoot.k8sVersion }}
       - name: SEED
         type: env
-        value: gcp
+        value: base
       - name: CLOUDPROFILE
         type: env
         value: aws

--- a/test/testruns/default/templates/_az-shoot.tpl
+++ b/test/testruns/default/templates/_az-shoot.tpl
@@ -7,7 +7,7 @@
       config:
       - name: SEED
         type: env
-        value: gcp
+        value: base
       - name: SHOOT_NAME
         type: env
         value: {{ .prefix }}

--- a/test/testruns/default/templates/_garden-config.tpl
+++ b/test/testruns/default/templates/_garden-config.tpl
@@ -1,0 +1,54 @@
+{{- define "garden-config" }}
+      - name: BASE_CLOUDPROVIDER
+        type: env
+        value: {{ .Values.baseCluster }}
+      - name: gcloud
+        type: file
+        path: "/tmp/garden/gcloud.json"
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: gcloud.json
+      - name: ACCESS_KEY_ID
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: accessKeyID
+      - name: SECRET_ACCESS_KEY_ID
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: secretAccessKey
+      - name: AZ_CLIENT_ID
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: clientID
+      - name: AZ_CLIENT_SECRET
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: clientSecret
+      - name: AZ_SUBSCRIPTION_ID
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: subscriptionID
+      - name: AZ_TENANT_ID
+        type: env
+        private: true
+        valueFrom:
+          secretKeyRef:
+            name: garden-test
+            key: tenantID
+{{- end }}

--- a/test/testruns/default/templates/_gcp-shoot.tpl
+++ b/test/testruns/default/templates/_gcp-shoot.tpl
@@ -5,6 +5,9 @@
       name: create-shoot
       locationSet: default
       config:
+      - name: SEED
+        type: env
+        value: base
       - name: SHOOT_NAME
         type: env
         value: {{ .prefix }}

--- a/test/testruns/default/templates/testrun-default.yaml
+++ b/test/testruns/default/templates/testrun-default.yaml
@@ -41,6 +41,10 @@ spec:
   - name: prepare-host
     definition:
       name: tm-scheduler-lock-gardener
+      config:
+      - name: HOST_CLOUDPROVIDER
+        type: env
+        value: {{ .Values.baseCluster }}
 
   - name: create-garden
     dependsOn: [ prepare-host ]
@@ -48,7 +52,7 @@ spec:
       name: create-garden
       location: default
       config:
-{{ toYaml .Values.garden.credentials.config | indent 6 }}
+      {{ include "garden-config" . }}
 
   {{ if or (has "platform/aws" .Values.labels) (not .Values.labels) }}
   {{ include "aws-shoot" (set . "prefix" ( printf "aws-%s" $prefix ) ) }}
@@ -108,7 +112,7 @@ spec:
     definition:
       name: delete-garden
       config:
-{{ toYaml .Values.garden.credentials.config | indent 6 }}
+      {{ include "garden-config" . }}
 
   - name: reset-host
     dependsOn: [ delete-garden ]
@@ -135,7 +139,7 @@ spec:
       continueOnError: true
       condition: error
       config:
-{{ toYaml .Values.garden.credentials.config | indent 6 }}
+      {{ include "garden-config" . }}
 
   - name: reset-host
     dependsOn: [ delete-garden ]

--- a/test/testruns/default/values.yaml
+++ b/test/testruns/default/values.yaml
@@ -15,57 +15,6 @@ gardensetup:
 gardener:
   version: master
 
-garden:
-  credentials:
-    config:
-    - name: gcloud
-      type: file
-      path: "/tmp/garden/gcloud.json"
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: gcloud.json
-    - name: ACCESS_KEY_ID
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: accessKeyID
-    - name: SECRET_ACCESS_KEY_ID
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: secretAccessKey
-    - name: AZ_CLIENT_ID
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: clientID
-    - name: AZ_CLIENT_SECRET
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: clientSecret
-    - name: AZ_SUBSCRIPTION_ID
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: subscriptionID
-    - name: AZ_TENANT_ID
-      type: env
-      private: true
-      valueFrom:
-        secretKeyRef:
-          name: garden-test
-          key: tenantID
+baseCluster: gcp
 
 labels: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Add integration test support for specific base clusters in PR's

new introduced labels:
- `base/aws`
- `base/gcp`
- `base/azure`

if multiple are defined the first one is taken as base cluster

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add integration test support for specific base clusters
```
