### PR TITLE
fix deletion process without gen folder

### DIFF
--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -78,11 +78,12 @@ state:
   gardener_controller_manager: (( utilities.certs.keyCertForCA(spec.controllermanager, gardener_ca, false) ))
 
 plugins:
-  - helm:
-    - gardener
-    - template
-  - kubectl:
-    - kubectl_apply
+  - pinned:
+    - helm:
+      - gardener
+      - template
+    - kubectl:
+      - kubectl_apply
   - kubectl:
     - garden_secret
 

--- a/components/gardener/virtual/export.yaml
+++ b/components/gardener/virtual/export.yaml
@@ -14,11 +14,9 @@
 
 ---
 gardener: (( &temporary ))
-gardener_git: (( &temporary ))
 settings: (( &temporary ))
 export:
   gardener:
     seedCandidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
     values: (( .gardener.values ))
-  gardener_git: (( .gardener_git ))
   dns_credentials: (( .settings.dns_credentials ))


### PR DESCRIPTION
**What this PR does / why we need it**:
#92 was supposed to enable deletion of a Gardener without the state folder. While this works for most of the components, it didn't work for all of them. 
This PR, in combination with https://github.com/gardener/sow/pull/21, fixes that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
⚠️ sow version 1.1.1 or higher is required
```
```improvement operator
The `gardener/virtual` component can now be deleted without an existing `gen` folder.
```
