### PR TITLE
Add support for multiple kubernetes versions in tests

### DIFF
--- a/test/acre.yaml
+++ b/test/acre.yaml
@@ -8,6 +8,10 @@
 # GARDENER_IMAGE_TAG: gardener apiserver, controllermanager and scheduler version
 # GARDENER_COMMIT: use a specific gardener commit
 
+# Specify the supported kubernetes versions for the cloudprofiles by using K8S_VERSION or a file at K8S_VERSIONS
+# K8S_VERSION: specify the kubernetes version
+
+# K8S_VERSIONS: path to a file containing offered kubernetes versions
 
 gcp-credentials:
   serviceaccount.json: (( read( "./gcloud.json", "text" ) ))
@@ -23,9 +27,12 @@ azure-credentials:
   tenantID: (( env( "AZ_TENANT_ID" ) ))
 
 k8sVersions:
-  kubernetes:
+  tmp:
+    <<: (( &temporary ))
     offeredVersions:
-    - version: (( env( "K8S_VERSION" ) || "1.14.3" ))
+    - version: (( env( "K8S_VERSION" ) || "1.14.4" ))
+  kubernetes:
+    (( read( env( "K8S_VERSIONS" ), "yaml") || tmp ))
 
 monitoring-credentials:
   username: (( env( "MONITORING_USERNAME" ) || ~~ ))


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for multiple kubernetes versions offered by the cloudprofile.
The versions can be specified by either setting one specify version via `env K8s_VERSION=1.x.x`
or by specifying a path to a yaml file containing these versions 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Integration test does now support multiple kubernetes versions
```
