### PR TITLE
Change Issuer to ClusterIssuer and minor fixes

### DIFF
--- a/components/cert-manager/cert/deployment.yaml
+++ b/components/cert-manager/cert/deployment.yaml
@@ -29,4 +29,4 @@ cert:
         - (( .settings.certificate.domain ))
         issuerRef:
           name: (( imports.cert-controller.export.issuerName ))
-          kind: Issuer
+          kind: ClusterIssuer

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -66,10 +66,9 @@ acme_issuer:
   manifests:
     - <<: (( valid( .settings.issuerPrivateKey ) ? *issuer-secret :~ ))
     - apiVersion: certmanager.k8s.io/v1alpha1
-      kind: Issuer
+      kind: ClusterIssuer
       metadata:
         name: (( settings.issuerName ))
-        namespace: (( .landscape.namespace ))
       spec:
         acme:
           server: (( .caSpec.url ))
@@ -93,16 +92,15 @@ ca_issuer:
       kind: Secret
       metadata:
         name: (( .settings.caSecret ))
-        namespace: (( .landscape.namespace ))
+        namespace: (( .settings.namespace ))
       type: kubernetes.io/tls
       data:
         tls.crt: (( base64( .settings.ca.crt ) ))
         tls.key: (( base64( .settings.ca.key ) ))
     - apiVersion: certmanager.k8s.io/v1alpha1
-      kind: Issuer
+      kind: ClusterIssuer
       metadata:
         name: (( settings.issuerName ))
-        namespace: (( .landscape.namespace ))
       spec:
         ca:
           secretName: (( .settings.caSecret ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -74,17 +74,6 @@ rbac:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        labels:
-          garden.sapcloud.io/role: admins
-        name: garden-administrators
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: garden.sapcloud.io:system:project-member
-      subjects: (( util.userbindings(spec.users) ))
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
         name: garden.sapcloud.io:system:project-creation
       roleRef:
         apiGroup: rbac.authorization.k8s.io

--- a/components/gardencontent/seeds/manifests/shoot_manifest.yaml
+++ b/components/gardencontent/seeds/manifests/shoot_manifest.yaml
@@ -36,4 +36,8 @@ spec:
       end: 230000+0100
     autoUpdate:
       kubernetesVersion: false
-  addons: (( values.values.iaas.addons || ~~ ))
+  addons:
+    <<: (( values.values.iaas.spec.addons || ~ ))
+    nginx-ingress:
+      enabled: true
+      loadBalancerSourceRanges: []

--- a/components/gardencontent/seeds/provider/aws/shoot.yaml
+++ b/components/gardencontent/seeds/provider/aws/shoot.yaml
@@ -32,29 +32,3 @@ spec:
     secretBindingRef:
       name: (( values.secretbinding ))
     seed: (( values.seed ))
-  addons:
-    kube2iam:
-      enabled: true
-      roles:
-      - name: ecr
-        description: "Allow access to ECR repositories beginning with 'my-images/', and creation of new repositories"
-        policy: |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Action": "ecr:*",
-                "Effect": "Allow",
-                "Resource": "arn:aws:ecr:eu-central-1:${account_id}:repository/my-images/*"
-              },
-              {
-                "Action": [
-                  "ecr:GetAuthorizationToken",
-                  "ecr:CreateRepository"
-                ],
-                "Effect": "Allow",
-                "Resource": "*"
-              }
-            ]
-          }
-

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -30,7 +30,7 @@ providerconfig:
   iaas: (( read(__ctx.DIR "/../provider/" v.type "/seed.yaml", "import") ))
   config: (( v ))
   seed:
-    ingressdomain: (( imports.ingress_dns.export.ingress_domain ))
+    ingressdomain: (( "ingress." name ".seed." .landscape.domain ))
     kubeconfig: (( imports.shoots.export.shoots[v.name].kubeconfig ))
     networks: (( {"nodes" = v.cluster.networks.nodes, "pods" = v.cluster.networks.pods, "services" = v.cluster.networks.services} ))
   secretname: (( name "-" v.mode ))

--- a/components/gardencontent/seeds/shoots/deployment.yaml
+++ b/components/gardencontent/seeds/shoots/deployment.yaml
@@ -50,7 +50,7 @@ shootconfig:
   values:
     name: (( v.name ))
     namespace: (( v.namespace || imports.project.export.project_namespace ))
-    domain: (( name "." imports.project.export.project_name ".seed." landscape.domain ))
+    domain: (( name ".seed." landscape.domain ))
     domain_secret: (( .settings.domain_secret ))
     iaas: (( read(__ctx.DIR "/../provider/" v.type "/shoot.yaml", "import") ))
     cloudprofile: (( v.cloudprofile || v.name ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -39,7 +39,7 @@ providerconfig:
   iaas: (( read(__ctx.DIR "/../provider/" v.type "/seed.yaml", "import") ))
   config: (( v ))
   seed:
-    ingressdomain: (( imports.ingress_dns.export.ingress_domain ))
+    ingressdomain: (( "ingress." name ".seed." .landscape.domain ))
     kubeconfig: (( asyaml( v.cluster.kubeconfig ) || read(env.ROOTDIR "/" landscape.clusters.[0].kubeconfig, "text") ))
     networks: (( v.cluster.networks || landscape.clusters.[0].networks ))
   secretname: (( name "-" v.mode ))

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -232,7 +232,11 @@ gardener:
           tag: (( .gardener_version.scheduler.image_tag || ~~ ))
         serviceAccountName: gardener-scheduler
         config:
-          candidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
+          schedulers:
+            shoot:
+              retrySyncPeriod: 15s
+              concurrentSyncs: 5
+              candidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
         kubeconfig: (( asyaml( imports.kube_apiserver.export.kubeconfig ) ))
       deployment:
         virtualGarden:


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The issuer deployed in the `cert-manager/controller` step is now a `ClusterIssuer` rather than an `Issuer`. This was done to make it easier to use the issuer for custom certificates.
```
```noteworthy operator
The shoot domain scheme has changed.
```
```improvement operator
A recent change in Gardener moved the position of the seed `candidateDeterminationStrategy` within the Gardener helm chart and went unnoticed, rendering the `landscape.gardener.seedCandidateDeterminationStrategy` field in the acre.yaml dysfunctional. This has been fixed now.
```
```improvement operator
A superflouous clusterrolebinding has been removed.
```
```improvement operator
Shooted seeds are now deployed with a nginx addon.
```