### PR TITLE
dashboard alternative domain and minor upgrades

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -141,7 +141,7 @@ landscape:
         helm_tag: "v0.9.1"
       cert-dns-bridge:
         <<: (( merge ))
-        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"1.0.0" ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"1.0.1" ))
         image_tag: (( valid( tag ) ? tag :~~ ))
         image_repo: (( ~~ ))
         repo: "https://github.com/gardener/certificate-dns-bridge.git"

--- a/acre.yaml
+++ b/acre.yaml
@@ -394,6 +394,23 @@ validation:
           - networks
           - (( validation.networks types.iaas[values.type].networks ))
   dashboard_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
+  dashboard_cname_validator:
+    - optionalfield
+    - cname
+    - - and
+      - - mapfield
+        - domain
+        - - dnsdomain
+      - - optionalfield
+        - dns
+        - - and
+          - - mapfield
+            - type
+            - - valueset
+              - (( keys( validation.types.dns ) ))
+          - - mapfield
+            - credentials
+            - (( types.dns[landscape.dashboard.cname.dns.type].credentials || [] ))
   gardener_validator: ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]]
   networks:
     - and
@@ -457,7 +474,7 @@ validation:
   ##### landscape.gardener
   gardener: (( defined( landscape.gardener ) ? validate( landscape.gardener, validation.gardener_validator ) :~~ ))
   ##### landscape.dashboard
-  dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator ) :~~ ))
+  dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator, validation.dashboard_cname_validator ) :~~ ))
   ##### landscape.certmanager
   cert-manager: (( validate( landscape.cert-manager, validation.cert-manager_validators.basic, [validation.cert-manager_validators.email, landscape.identity] ) ))
   ##### landscape.identity TODO

--- a/components/cert-manager/cert/deployment.yaml
+++ b/components/cert-manager/cert/deployment.yaml
@@ -5,7 +5,9 @@ landscape: (( &temporary ))
 settings:
   certificate:
     name: dashboard-identity-ingress
-    domain: (( "*." imports.ingress-controller.export.ingress_domain ))
+    domains:
+      - (( "*." imports.ingress-controller.export.ingress_domain ))
+      - (( .landscape.dashboard.cname.domain || ~~ ))
     secret_name: identity-dashboard-tls
     namespace: (( landscape.namespace ))
 
@@ -24,9 +26,7 @@ cert:
       spec:
         secretName: (( .settings.certificate.secret_name ))
         renewBefore: 360h # 15d
-        commonName: (( .settings.certificate.domain ))
-        dnsNames:
-        - (( .settings.certificate.domain ))
+        dnsNames: (( .settings.certificate.domains ))
         issuerRef:
           name: (( imports.cert-controller.export.issuerName ))
           kind: ClusterIssuer

--- a/components/dashboard/component.yaml
+++ b/components/dashboard/component.yaml
@@ -23,6 +23,7 @@ component:
     - kube_apiserver: kube-apiserver
     - cert: cert-manager/cert
     - cert-controller: cert-manager/controller
+    - dns-controller
 
   plugins:
     - git

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -19,6 +19,7 @@ landscape: (( &temporary ))
 plugins:
   - helm: dashboard
   - kubectl: rbac
+  - (( valid( .landscape.dashboard.cname ) ? { "kubectl" = "cname_dnsentry" } :~~ ))
   - -echo: "==================================================================="
   - -echo: (( "Dashboard URL -> " settings.dashboard_url ))
   - -echo: "==================================================================="
@@ -35,6 +36,7 @@ dashboard:
     sessionSecret: (( rand("[:alnum:]", 30) ))
     hosts:
       - (( imports.identity.export.dashboard_dns ))
+      - (( .landscape.dashboard.cname.domain || ~~ ))
     image:
       repository: (( .dashboard_version.image_repo || ~~ ))
       tag: (( .dashboard_version.image_tag || ~~ ))
@@ -51,6 +53,22 @@ dashboard:
     frontendConfig:
       <<: (( .landscape.dashboard.frontendConfig || ~ ))
       seedCandidateDeterminationStrategy: (( .imports.gardener_virtual.export.gardener.seedCandidateDeterminationStrategy ))
+
+cname_dnsentry:
+  kubeconfig: (( .landscape.clusters[0].kubeconfig ))
+  manifests:
+    - apiVersion: dns.gardener.cloud/v1alpha1
+      kind: DNSEntry
+      metadata:
+        annotations:
+          dns.gardener.cloud/class: (( .imports.dns-controller.export.dns-class ))
+        name: garden-dashboard-cname
+        namespace: (( .imports.dns-controller.export.namespace ))
+      spec:
+        dnsName: (( .landscape.dashboard.cname.domain || ~~ ))
+        targets:
+        - (( .imports.identity.export.dashboard_dns ))
+        ttl: 120
 
 util:
   <<: (( &temporary ))

--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -32,12 +32,18 @@ helm:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   source: "git/repo/charts/external-dns-management"
   name: (( settings.fullname ))
-  namespace: (( .spec.namespace ))
+  namespace: (( .spec.common.namespace ))
   values: (( .spec.helm ))
 
 kubectl:
-  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "provider_secret.yaml", landscape.clusters.[0].kubeconfig, .spec ) ))
-  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "dns_provider.yaml", landscape.clusters.[0].kubeconfig, .spec ) ))
+  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "provider_secret.yaml", landscape.clusters.[0].kubeconfig, .spec.dns ) ))
+  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "dns_provider.yaml", landscape.clusters.[0].kubeconfig, .spec.dns ) ))
+  - <<: (( valid( .landscape.dashboard.cname ) ? *.kubectl_cname_template :~~ ))
+
+kubectl_cname_template:
+  - <<: (( &template &temporary ))
+  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "provider_secret.yaml", landscape.clusters.[0].kubeconfig, .spec.cname ) ))
+  - (( utilities.kubectl.generate( __ctx.DIR "/manifests/" "dns_provider.yaml", landscape.clusters.[0].kubeconfig, .spec.cname ) ))
 
 providers:
   <<: (( &temporary ))
@@ -45,42 +51,60 @@ providers:
     <<: (( &template ))
     name: aws
     credentials:
-      AWS_ACCESS_KEY_ID: (( landscape.dns.credentials.accessKeyID ))
-      AWS_SECRET_ACCESS_KEY: (( landscape.dns.credentials.secretAccessKey ))
-      AWS_REGION: (( landscape.dns.credentials.region || ~~ ))
+      AWS_ACCESS_KEY_ID: (( node.credentials.accessKeyID ))
+      AWS_SECRET_ACCESS_KEY: (( node.credentials.secretAccessKey ))
+      AWS_REGION: (( node.credentials.region || ~~ ))
   google-clouddns:
     <<: (( &template ))
     name: google
     credentials:
-      serviceaccount.json: (( landscape.dns.credentials.["serviceaccount.json"] ))
+      serviceaccount.json: (( node.credentials.["serviceaccount.json"] ))
   azure-dns:
     <<: (( &template ))
     name: azure
     credentials:
-      AZURE_CLIENT_ID: (( landscape.dns.credentials.clientID ))
-      AZURE_CLIENT_SECRET: (( landscape.dns.credentials.clientSecret ))
-      AZURE_SUBSCRIPTION_ID: (( landscape.dns.credentials.subscriptionID ))
-      AZURE_TENANT_ID: (( landscape.dns.credentials.tenantID ))
+      AZURE_CLIENT_ID: (( node.credentials.clientID ))
+      AZURE_CLIENT_SECRET: (( node.credentials.clientSecret ))
+      AZURE_SUBSCRIPTION_ID: (( node.credentials.subscriptionID ))
+      AZURE_TENANT_ID: (( node.credentials.tenantID ))
   openstack-designate:
     <<: (( &template ))
     name: openstack
     credentials:
-      OS_AUTH_URL: (( landscape.dns.credentials.authURL ))
-      OS_REGION_NAME: (( landscape.dns.credentials.region ))
-      OS_USERNAME: (( landscape.dns.credentials.username ))
-      OS_PASSWORD: (( landscape.dns.credentials.password ))
-      OS_DOMAIN_NAME: (( landscape.dns.credentials.domainName ))
-      OS_USER_DOMAIN_NAME: (( landscape.dns.credentials.userDomainName || "" ))
-      OS_PROJECT_NAME: (( landscape.dns.credentials.tenantName ))
+      OS_AUTH_URL: (( node.credentials.authURL ))
+      OS_REGION_NAME: (( node.credentials.region ))
+      OS_USERNAME: (( node.credentials.username ))
+      OS_PASSWORD: (( node.credentials.password ))
+      OS_DOMAIN_NAME: (( node.credentials.domainName ))
+      OS_USER_DOMAIN_NAME: (( node.credentials.userDomainName || "" ))
+      OS_PROJECT_NAME: (( node.credentials.tenantName ))
+
+func:
+  <<: (( &temporary ))
+  instantiateProvider: (( |type,node|-> *.providers[type] ))
 
 spec:
   <<: (( &temporary ))
-  secret_name: (( settings.fullname "-" provider.name ))
-  type: (( .landscape.dns.type ))
-  provider: (( *providers.[type] ))
-  domain: (( .landscape.domain ))
-  zones: (( .landscape.dns.hostedZoneIDs || ~~ ))
-  namespace: "kube-system"
+  common:
+    namespace: "kube-system"
+    dns_class: (( .settings.dns-class ))
+  dns:
+    type: (( .landscape.dns.type ))
+    provider: (( .func.instantiateProvider( type, .landscape.dns ) ))
+    domain: (( .landscape.domain ))
+    zones: (( .landscape.dns.hostedZoneIDs || ~~ ))
+    secret_name: (( .settings.fullname "-" provider.name ))
+    provider_name: (( provider.name ))
+    <<: (( common ))
+  cname:
+    dns_fallback: (( .landscape.dashboard.cname.dns || .landscape.dns ))
+    type: (( dns_fallback.type ))
+    provider: (( .func.instantiateProvider( type, dns_fallback ) ))
+    domain: (( .landscape.dashboard.cname.domain || ~~ ))
+    zones: (( dns_fallback.hostedZoneIDs || ~~ ))
+    secret_name: (( .settings.fullname "-" provider.name "-cname" ))
+    provider_name: (( provider.name "-cname" ))
+    <<: (( common ))
   helm:
     nameOverride: (( settings.fullname ))
     fullnameOverride: (( settings.fullname ))
@@ -89,7 +113,7 @@ spec:
       repository: (( .landscape.versions.dns-controller.image_repo || ~~ ))
     createCRDs: true
     configuration:
-      dnsClass: (( settings.dns-class ))
+      dnsClass: (( common.dns_class ))
       identifier: (( "setup.gardener.cloud/" .landscape.name ))
-      controllers: (( "dnssources," type ))
+      controllers: (( "dnssources," dns.type ( cname.type != dns.type ? "," cname.type :"" ) ))
       ttl: (( .landscape.dns.ttl || ~~ ))

--- a/components/dns-controller/manifests/dns_provider.yaml
+++ b/components/dns-controller/manifests/dns_provider.yaml
@@ -15,9 +15,9 @@
 apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSProvider
 metadata:
-  name: (( values.provider.name ))
+  name: (( values.provider_name ))
   namespace: (( values.namespace ))
-  annotations: (( { "dns.gardener.cloud/class"=values.helm.configuration.dnsClass} || ~ ))
+  annotations: (( { "dns.gardener.cloud/class"=values.dns_class} || ~~ ))
   
 spec:
   type: (( values.type ))

--- a/components/tiller/deployment.yaml
+++ b/components/tiller/deployment.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-landscape:
+landscape: (( &temporary ))
 
 plugins:
   - kubectl

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -1,9 +1,28 @@
 # Advanced Configuration Options for 'landscape.dashboard'
 
-The `landscape.dashboard` node is entirely optional. There are basically two nodes in it that are evaluated:
+The `landscape.dashboard` node is entirely optional. There are basically three nodes in it that are evaluated:
 - `landscape.dashboard.frontendConfig`
 - `landscape.dashboard.gitHub`
+- `landscape.dashboard.cname`
 
-The contents of both nodes will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values. 
+The contents of the first two will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values.
 
 Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).
+
+### landscape.dashboard.cname
+
+With `landscape.dashboard.cname`, you can provide another domain from which the dashboard will be reachable.
+```yaml
+  ...
+  dashboard:
+    ...
+    cname:
+      domain: dashboard.my-other-domain.org
+      dns:   # optional
+        type: <google-clouddns|aws-route53|azure-dns|openstack-designate>
+        credentials: ...
+```
+If you specify `landscape.dashboard.cname`, the `domain` field has to exist. A `CNAME` DNS entry will be created for that domain, pointing to the Gardener dashboard domain. This differs from `landscape.domain`, where you enter a base domain for your cluster and the dashboard will be available on a subdomain of that domain - this one will point directly to the dashboard.
+The `dns` field follows the same structure as `landscape.dns`. If the domain is managed by the same account on the same cloud provider as the one given in `landscape.dns`, you can remove the `dns` field completely, in which case it will use the same values as `landscape.dns`.
+
+The given domain will be included in the generated certificate. If you use untrusted certificates (e.g. self-signed or from the letsencrypt staging server) and access the dashboard via the domain given here


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `landscape` node in the tiller `deployment.yaml` file is now temporary.
```
```improvement operator
The certificate-dns-bridge has been updated to also work on clusters running kubernetes 1.16 or higher.
```
```noteworthy operator
It is now possible to provide an alternative domain for the Gardener dashboard. Check the [documentation](docs/extended/dashboard.md) for details.
```
