### PR TITLE
kube-apiserver: change hostpath to emptydir

### DIFF
--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -256,8 +256,6 @@ spec:
         secret:
           secretName: garden-kube-aggregator
       - name: etcssl
-        hostPath:
-          path: /etc/ssl
+        emptyDir: {}
       - name: ssl-certs-hosts
-        hostPath:
-          path: /usr/share/ca-certificates
+        emptyDir: {}


### PR DESCRIPTION

**What this PR does / why we need it**:
hostPath is restricted for [security reasons](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/). kube-apiserver doesn't need it. Switching to emptyDir
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
