### PR TITLE
remove trivially used hostpath

### DIFF
--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -166,12 +166,6 @@ spec:
           mountPath: /srv/kubernetes/auth
         - name: kube-aggregator
           mountPath: /srv/kubernetes/aggregator
-        - name: etcssl
-          mountPath: /etc/ssl
-          readOnly: true
-        - name: ssl-certs-hosts
-          mountPath: /usr/share/ca-certificates
-          readOnly: true
         {{- if .Values.tls.identity.ca }}
         - name: ca-identity
           mountPath: /srv/kubernetes/identity-ca
@@ -255,9 +249,3 @@ spec:
       - name: kube-aggregator
         secret:
           secretName: garden-kube-aggregator
-      - name: etcssl
-        hostPath:
-          path: /etc/ssl
-      - name: ssl-certs-hosts
-        hostPath:
-          path: /usr/share/ca-certificates


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the hostpaths that are not really used. This hostpath creates troubles when mkdir on read-only filesystems
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
@mvladev @ialidzhikov 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Remove unused hostpaths
```
