### PR TITLE
Fix bucket name

### DIFF
--- a/components/etcd/backupinfra/deployment.yaml
+++ b/components/etcd/backupinfra/deployment.yaml
@@ -27,5 +27,5 @@ terraform:
   source: (( temp.dir ))
   values:
     <<: (( temp.addon ))
-    BUCKETNAME: (( landscape.name "-etcd-bucket" ))
+    BUCKETNAME: (( substr( landscape.name, 0, 25 ) "-etcd-bucket" ))
     REGION: (( landscape.etcd.backup.region ))


### PR DESCRIPTION
**What this PR does / why we need it**:

AWS S3 doesn't like bucket names with a length greater than 37 characters. 
With this PR, garden-setup only uses the first 25 characters of the landscape name (instead of a complete one) as prefix for the etcd bucket name. Together with the `-etcd-bucket` suffix, this will create bucket names with a maximum length of 37 characters.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
To avoid problems with too long etcd bucket names on AWS (S3), only the first 25 characters of `landscape.name` go into the bucket name now (before: the whole name). Note that this applies to all infrastructures and that multiple landscapes should differ in the first 25 characters of their names to avoid conflicting buckets.
⚠️ If you deploy the `etcd/backupinfra` component over an existing landscape with a name longer than 25 characters, this will trigger a deletion and re-creation of the etcd backup bucket!
```
