### PR TITLE
Update Kubernetes versions to 1.16.3, 1.15.6 and 1.14.9

### DIFF
--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -46,9 +46,9 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - version: 1.16.2
-      - version: 1.15.5
-      - version: 1.14.8
+      - version: 1.16.3
+      - version: 1.15.6
+      - version: 1.14.9
       - version: 1.13.12
       - version: 1.12.10
       - version: 1.11.10

--- a/components/gardencontent/profiles/provider/azure/iaas.yaml
+++ b/components/gardencontent/profiles/provider/azure/iaas.yaml
@@ -14,15 +14,6 @@
 
 <<: (( &template ))
 
-kubernetes:
-  versions:
-    - version: 1.16.1
-    - version: 1.15.4
-    - version: 1.14.8
-    - version: 1.13.12
-    - version: 1.12.10
-    - version: 1.11.10
-
 machineTypes:
   - cpu: "2"
     gpu: "0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Kubernetes versions to 1.16.3, 1.15.6 and 1.14.9.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Kubernetes versions have been updated to the newest patch version (v1.16.3, v1.15.6 and v1.14.9).
```
