### PR TITLE
enable activating/deactivating network policies

### DIFF
--- a/.test-defs/CreateGarden.yaml
+++ b/.test-defs/CreateGarden.yaml
@@ -8,7 +8,7 @@ spec:
 
   description: Create a garden cluster
 
-  activeDeadlineSeconds: 1200
+  activeDeadlineSeconds: 3600
 
   command: [bash, -c]
   args: ["./test/scripts/create"]

--- a/acre.yaml
+++ b/acre.yaml
@@ -411,7 +411,16 @@ validation:
           - - mapfield
             - credentials
             - (( types.dns[landscape.dashboard.cname.dns.type].credentials || [] ))
-  gardener_validator: ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]]
+  gardener_validator:
+    - and
+    - - optionalfield
+      - seedCandidateDeterminationStrategy
+      - ["valueset", ["SameRegion", "MinimalDistance"]]
+    - - optionalfield
+      - network-policies
+      - - mapfield
+        - active
+        - ["type", "bool"]
   networks:
     - and
     - ["mapfield", "nodes", "cidr"]

--- a/components/dashboard/component.yaml
+++ b/components/dashboard/component.yaml
@@ -24,7 +24,7 @@ component:
     - cert: cert-manager/cert
     - cert-controller: cert-manager/controller
     - dns-controller
-    - network-policies
+    - (( ( .landscape.gardener.network-policies.active || false ) ? "network-policies" :~~ ))
 
   plugins:
     - git

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -50,6 +50,7 @@ dashboard:
     tls: ~
     kubeconfig: (( asyaml(imports.kube_apiserver.export.kubeconfig) ))
     podLabels:
+      <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))
       networking.gardener.cloud/to-dns: allowed
       networking.gardener.cloud/to-garden-kube-apiserver: allowed
       networking.gardener.cloud/to-identity: allowed

--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -43,6 +43,7 @@ spec:
       labels:
         app: garden
         component: kube-apiserver
+        {{- if .Values.networkPolicies }}
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-etcd: allowed
         networking.gardener.cloud/to-gardener-apiserver: allowed
@@ -51,6 +52,7 @@ spec:
         networking.gardener.cloud/to-ingress: allowed # needed for communication to identity
         networking.gardener.cloud/to-terminal-controller-manager: allowed # needed for webhooks
         networking.gardener.cloud/to-world: allowed # necessary, except for GCP because GCP puts IP table rules on the nodes that allow in-cluster routing
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/components/kube-apiserver/component.yaml
+++ b/components/kube-apiserver/component.yaml
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 ---
+landscape: (( &temporary ))
 component:
   imports:
     - ingress_controller: ingress-controller
     - etcd: etcd/cluster
     - identity
     - namespace
-    - network-policies
+    - (( ( .landscape.gardener.network-policies.active || false ) ? "network-policies" :~~ ))
     - cert-controller: cert-manager/controller
 
   stubs:

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -116,3 +116,4 @@ kubeapiserver:
       secretNames:
         ca: garden-etcd-main-ca
         client: garden-etcd-main-client
+    networkPolicies: (( .landscape.gardener.network-policies.active || false ))

--- a/components/network-policies/action
+++ b/components/network-policies/action
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$SOWLIB/k8s"
+
+label_kube_system()
+{
+  if [ "$1" = "deploy" ]; then
+    PLUGIN_setup label_kube_system
+    K8S_setKubeConfig "$PLUGININSTANCE" 
+    kubectl label --overwrite namespace kube-system role=kube-system
+  fi
+}

--- a/components/network-policies/component.yaml
+++ b/components/network-policies/component.yaml
@@ -1,4 +1,6 @@
 ---
+landscape: (( &temporary ))
 component:
+  active: (( .landscape.gardener.network-policies.active || false ))
   imports:
     - namespace

--- a/components/network-policies/deployment.yaml
+++ b/components/network-policies/deployment.yaml
@@ -3,7 +3,11 @@ landscape: (( &temporary ))
 imports: (( &temporary ))
 
 plugins:
+  - label_kube_system
   - kubectl
+
+label_kube_system:
+  kubeconfig: (( .landscape.clusters[0].kubeconfig ))
 
 kubectl:
   kubeconfig: (( .landscape.clusters[0].kubeconfig ))

--- a/components/network-policies/manifests/to-dns.yaml
+++ b/components/network-policies/manifests/to-dns.yaml
@@ -1,4 +1,4 @@
-# Allows outgoing traffic to the pods responsible for DNS.
+# Allows outgoing traffic on port 53 (DNS) as well as traffic to kube-dns/coredns pods.
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -12,6 +12,11 @@ spec:
   policyTypes:
   - Egress
   egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
   - to:
     - namespaceSelector:
         matchLabels:

--- a/components/network-policies/manifests/to-gardener-controller-manager.yaml
+++ b/components/network-policies/manifests/to-gardener-controller-manager.yaml
@@ -1,3 +1,4 @@
+# Allows outgoing traffic to the gardener-controller-manager pod.
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -1,3 +1,10 @@
 # Advanced Configuration Options for 'landscape.gardener'
 
-There is only one configuration option for `landscape.gardener` and that is `landscape.gardener.seedCandidateDeterminationStrategy`. The two possible values are `SameRegion` (default) and `MinimalDistance`. In the first case, shoots can only be created in regions where a seed exists and only those regions will show up in the dashboard. In the latter case, shoots can be created in any region listed in the cloudprofile and the geographically closest seed will be used.
+### Seed Candidate Determination Strategy
+`landscape.gardener.seedCandidateDeterminationStrategy` has two possible values: `SameRegion` (default) and `MinimalDistance`. In the first case, shoots can only be created in regions where a seed exists and only those regions will show up in the dashboard. In the latter case, shoots can be created in any region listed in the cloudprofile and the geographically closest seed will be used.
+
+
+### Network Policies
+If `landscape.gardener.network-policies.active` is set to `true`, garden-setup will deploy network policies into the `garden` namespace. Currently, these are only egress rules for the 'virtual' kube-apiserver and the Gardener dashboard, other components or incoming traffic are not affected for now.
+
+The default for `landscape.gardener.network-policies.active` is `false`, because the network policies have been shown to cause problems in some environments. It is planned to enable the policies by default, though, once the problems have been solved.

--- a/test/acre.yaml
+++ b/test/acre.yaml
@@ -123,6 +123,10 @@ landscape:
       pods: 10.28.0.0/15
       services: 10.31.240.0/20
 
+  gardener:
+    network-policies:
+      active: (( env( "NETWORK_POLICIES" ) || true ))
+
   iaas:
   - name: base
     mode: seed


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement noteworthy
The network policies in the `garden` namespace can now be switched on and off by setting `landscape.gardener.network-policies.active`. The default is `false` (meaning the network policies are not deployed by default).
```
```improvement operator
The `to-dns` network policy has been reworked as it didn't work in all environments.
```