### PR TITLE
add dashboard terminals

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -114,6 +114,13 @@ landscape:
           chart_path: controllers/networking-calico/charts/networking-calico
           image_tag: (( valid( networking-calico.tag ) ? networking-calico.tag :~~ ))
           image_repo: (( ~~ ))
+        shoot-cert-service:
+          <<: (( merge ))
+          tag: (( valid( shoot-cert-service.branch ) -or valid( shoot-cert-service.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.shoot-cert-service.version ))
+          repo: (( .dependency_versions.versions.gardener.extensions.shoot-cert-service.repo ))
+          chart_path: controllers/extension-shoot-cert-service/charts/extension-shoot-cert-service
+          image_tag: (( valid( shoot-cert-service.tag ) ? shoot-cert-service.tag :~~ ))
+          image_repo: (( ~~ ))
     dashboard:
       <<: (( merge ))
       repo: (( .dependency_versions.versions.dashboard.core.repo ))
@@ -125,6 +132,12 @@ landscape:
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.dashboard.identity.version ))
       branch: (( valid( commit ) ? ~~ :( dashboard.branch || ~~ ) ))
       commit: (( dashboard.commit || ~~ ))
+    terminal-controller-manager:
+      <<: (( merge ))
+      repo: https://github.com/gardener/terminal-controller-manager.git
+      image_tag: (( valid( tag ) ? tag :~~ ))
+      image_repo: (( ~~ ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.5.0" ))
     dns-controller:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))
@@ -393,24 +406,45 @@ validation:
         - - mapfield
           - networks
           - (( validation.networks types.iaas[values.type].networks ))
-  dashboard_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
-  dashboard_cname_validator:
-    - optionalfield
-    - cname
-    - - and
-      - - mapfield
-        - domain
-        - - dnsdomain
-      - - optionalfield
-        - dns
-        - - and
-          - - mapfield
-            - type
-            - - valueset
-              - (( keys( validation.types.dns ) ))
-          - - mapfield
-            - credentials
-            - (( types.dns[landscape.dashboard.cname.dns.type].credentials || [] ))
+  dashboard_validator:
+    - and
+    - - optionalfield
+      - cname
+      - - and
+        - - mapfield
+          - domain
+          - - dnsdomain
+        - - optionalfield
+          - dns
+          - - and
+            - - mapfield
+              - type
+              - - valueset
+                - (( keys( validation.types.dns ) ))
+            - - mapfield
+              - credentials
+              - (( types.dns[landscape.dashboard.cname.dns.type].credentials || [] ))
+    - - optionalfield
+      - terminals
+      - - and
+        - - mapfield
+          - active
+          - - type
+            - bool
+        - - optionalfield
+          - cert
+          - - and
+            - - optionalfield
+              - email
+              - - match
+                - (( validation.email_regex ))
+            - - optionalfield
+              - server
+            - - optionalfield
+              - privateKey
+              - privatekey
+  dashboard_no_seed_strategy_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
+  dashboard_terminals_validator: (( |db,cm|-> [! (( db.terminals.active || false ) -and ( cm.server.url == "self-signed" -or cm.server.url == "staging" )), "valid", "the 'dashboard terminals' feature requires trusted certificates, please configure the cert-manager accordingly"] ))
   gardener_validator:
     - and
     - - optionalfield
@@ -444,6 +478,9 @@ validation:
           - - optionalfield
             - ca
             - ["and", [(( cert-manager_validators.selfsigned )), (( landscape.cert-manager.server.url ))], [(( cert-manager_validators.acme )), (( landscape.cert-manager.server.url ))]]
+      - - optionalfield
+        - privateKey
+        - privatekey
     selfsigned: (( |ca,url|-> [url == "self-signed" ? valid( ca.crt ) -and valid( ca.key ) :true, "valid", "if 'landscape.cert-manager.server.url' is set to 'self-signed', you should either specify a CA with key ('server.ca.crt' and 'server.ca.key' set), or no CA at all ('server.ca' node not present)"] ))
     acme: (( |ca,url|-> [url != "self-signed" ? valid( ca.crt ) -and ( ! defined( ca.key ) ) :true, "if 'landscape.cert-manager.server.url' is not set to 'self-signed', you should either specify a CA without key ('server.ca.crt' set, no 'server.ca.key'), or the 'server.ca' node should not be present at all"] ))
     email: (( |ca,id|-> [valid( ca.email ) -or valid( id.users[0].email ), "either 'landscape.cert-manager.email' or 'landscape.identity.users[0].email' needs to be set"] ))
@@ -483,7 +520,7 @@ validation:
   ##### landscape.gardener
   gardener: (( defined( landscape.gardener ) ? validate( landscape.gardener, validation.gardener_validator ) :~~ ))
   ##### landscape.dashboard
-  dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator, validation.dashboard_cname_validator ) :~~ ))
+  dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator, validation.dashboard_no_seed_strategy_validator, [validation.dashboard_terminals_validator, landscape.cert-manager] ) :~~ ))
   ##### landscape.certmanager
   cert-manager: (( validate( landscape.cert-manager, validation.cert-manager_validators.basic, [validation.cert-manager_validators.email, landscape.identity] ) ))
   ##### landscape.identity TODO

--- a/acre.yaml
+++ b/acre.yaml
@@ -56,61 +56,61 @@ landscape:
           tag: (( valid( dns-external.branch ) -or valid( dns-external.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))
           image_tag: (( valid( dns-external.tag ) ? dns-external.tag :~~ ))
           image_repo: (( ~~ ))
-          repo: https://github.com/gardener/external-dns-management.git
+          repo: (( .dependency_versions.versions.gardener.extensions.dns-external.repo ))
           chart_path: charts/external-dns-management
         os-coreos:
           <<: (( merge ))
           tag: (( valid( os-coreos.branch ) -or valid( os-coreos.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-coreos.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.os-coreos.repo ))
           chart_path: controllers/os-coreos/charts/os-coreos
           image_tag: (( valid( os-coreos.tag ) ? os-coreos.tag :~~ ))
           image_repo: (( ~~ ))
         os-ubuntu:
           <<: (( merge ))
           tag: (( valid( os-ubuntu.branch ) -or valid( os-ubuntu.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-ubuntu.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.os-ubuntu.repo ))
           chart_path: controllers/os-ubuntu/charts/os-ubuntu
           image_tag: (( valid( os-ubuntu.tag ) ? os-ubuntu.tag :~~ ))
           image_repo: (( ~~ ))
         os-suse-jeos:
           <<: (( merge ))
           tag: (( valid( os-suse-jeos.branch ) -or valid( os-suse-jeos.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-suse-jeos.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.os-suse-jeos.repo ))
           chart_path: controllers/os-suse-jeos/charts/os-suse-jeos
           image_tag: (( valid( os-suse-jeos.tag ) ? os-suse-jeos.tag :~~ ))
           image_repo: (( ~~ ))
         provider-aws:
           <<: (( merge ))
           tag: (( valid( provider-aws.branch ) -or valid( provider-aws.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-aws.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.provider-aws.repo ))
           chart_path: controllers/provider-aws/charts/provider-aws
           image_tag: (( valid( provider-aws.tag ) ? provider-aws.tag :~~ ))
           image_repo: (( ~~ ))
         provider-gcp:
           <<: (( merge ))
           tag: (( valid( provider-gcp.branch ) -or valid( provider-gcp.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-gcp.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.provider-gcp.repo ))
           chart_path: controllers/provider-gcp/charts/provider-gcp
           image_tag: (( valid( provider-gcp.tag ) ? provider-gcp.tag :~~ ))
           image_repo: (( ~~ ))
         provider-azure:
           <<: (( merge ))
           tag: (( valid( provider-azure.branch ) -or valid( provider-azure.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-azure.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.provider-azure.repo ))
           chart_path: controllers/provider-azure/charts/provider-azure
           image_tag: (( valid( provider-azure.tag ) ? provider-azure.tag :~~ ))
           image_repo: (( ~~ ))
         provider-openstack:
           <<: (( merge ))
           tag: (( valid( provider-openstack.branch ) -or valid( provider-openstack.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-openstack.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.provider-openstack.repo ))
           chart_path: controllers/provider-openstack/charts/provider-openstack
           image_tag: (( valid( provider-openstack.tag ) ? provider-openstack.tag :~~ ))
           image_repo: (( ~~ ))
         networking-calico:
           <<: (( merge ))
           tag: (( valid( networking-calico.branch ) -or valid( networking-calico.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.networking-calico.version ))
-          repo: https://github.com/gardener/gardener-extensions.git
+          repo: (( .dependency_versions.versions.gardener.extensions.networking-calico.repo ))
           chart_path: controllers/networking-calico/charts/networking-calico
           image_tag: (( valid( networking-calico.tag ) ? networking-calico.tag :~~ ))
           image_repo: (( ~~ ))

--- a/components/dashboard/component.yaml
+++ b/components/dashboard/component.yaml
@@ -25,6 +25,7 @@ component:
     - cert-controller: cert-manager/controller
     - dns-controller
     - (( ( .landscape.gardener.network-policies.active || false ) ? "network-policies" :~~ ))
+    - (( ( .landscape.dashboard.terminals.active || false ) ? "terminals" :~~ ))
 
   plugins:
     - git

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -60,6 +60,30 @@ dashboard:
     frontendConfig:
       <<: (( .landscape.dashboard.frontendConfig || ~ ))
       seedCandidateDeterminationStrategy: (( .imports.gardener_virtual.export.gardener.seedCandidateDeterminationStrategy ))
+    terminal: (( ( .landscape.dashboard.terminals.active || false ) ? *.terminal_config :~~ ))
+
+terminal_config:
+  <<: (( &temporary &template ))
+  containerImage: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.6.0
+  containerImageOperator: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.6.0
+  gardenTerminalHost:
+    seedRef: (( .landscape.iaas[0].name ))
+  garden:
+    operatorCredentials:
+      secretRef:
+        name: (( .imports.terminals.export.kubeconfig_secret ))
+        namespace: (( .landscape.namespace ))
+  bootstrap:
+    disabled: false
+    shootDisabled: false
+    seedDisabled: false
+    gardenTerminalHostDisabled: true
+    apiServerIngress:
+      annotations:
+        certmanager.k8s.io/cluster-issuer: (( .imports.cert-controller.export.issuerName ))
+        cert.gardener.cloud/purpose: managed
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/backend-protocol: HTTPS
 
 cname_dnsentry:
   kubeconfig: (( .landscape.clusters[0].kubeconfig ))

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -36,5 +36,6 @@ deployment:
     - dns-external
     - networking-calico
     - <<: (( sum[.infrastructures|[]|s,e|-> s [ "provider-" e ]] ))
+    - (( ( .landscape.dashboard.terminals.active || false ) ? "shoot-cert-service" :~~ ))
 
 infrastructures: (( &temporary ( uniq( sum[.landscape.iaas|[]|s,e|-> s e.type ( e.seeds.[*].type || ~ ) ] ) ) ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -462,3 +462,32 @@ extension_manifests:
       resources:
       - kind: Network
         type: calico
+
+########################################
+  shoot-cert-service:
+########################################
+    <<: (( &template ))
+    apiVersion: core.gardener.cloud/v1alpha1
+    kind: ControllerRegistration
+    metadata:
+      name: shoot-cert-service
+    spec:
+      deployment:
+        type: helm
+        providerConfig:
+          chart: (( encoded_chart ))
+          values:
+            certificateConfig:
+              defaultIssuer:
+                name: garden
+                acme:
+                  email: (( valid( landscape.dashboard.terminals.cert.email ) ? landscape.dashboard.terminals.cert.email :( landscape.cert-manager.email || landscape.identity.users[0].email ) ))
+                  server: (( valid( landscape.dashboard.terminals.cert.server ) ? landscape.dashboard.terminals.cert.server :( landscape.cert-manager.server.url == "live" ? "https://acme-v02.api.letsencrypt.org/directory" :landscape.cert-manager.server.url ) ))
+                  privateKey: (( ( valid( landscape.dashboard.terminals.cert.privateKey ) ? landscape.dashboard.terminals.cert.privateKey :( ! valid( landscape.dashboard.terminals.cert.server ) ? landscape.cert-manager.privateKey :~~ ) ) || ~~ ))
+            image:
+              repo: (( version.image_repo || ~~ ))
+              tag: (( version.image_tag || ~~ ))
+      resources:
+      - kind: Extension
+        type: shoot-cert-service
+        globallyEnabled: true

--- a/components/terminals/component.yaml
+++ b/components/terminals/component.yaml
@@ -1,0 +1,22 @@
+---
+landscape: (( &temporary ))
+component:
+  active: (( .landscape.dashboard.terminals.active || false ))
+  imports:
+    - kube-apiserver
+    - ingress-controller
+    - cert-manager/solver
+    - gardener/runtime
+
+  plugins:
+    - git
+
+  stubs:
+    - lib/templates/utilities.yaml
+    - lib/templates/state.yaml
+    - lib/templates/certs.yaml
+
+git:
+  <<: (( .landscape.versions.terminal-controller-manager ))
+  files:
+    - config

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -1,0 +1,107 @@
+---
+imports: (( &temporary ))
+landscape: (( &temporary ))
+utilities: (( &temporary ))
+env: (( &temporary ))
+
+plugins:
+  - pinned:
+    - kustomize: kustomize.virtual.render
+    - kubectl: kustomize.virtual.apply
+  - kubectl
+  - pinned:
+    - kustomize-edit: kustomize.runtime.edit
+    - kustomize: kustomize.runtime.render
+    - kubectl: kustomize.runtime.apply
+
+kubectl:
+  kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
+  manifests:
+    - apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: (( settings.kubeconfig_secret ))
+        namespace: (( .landscape.namespace ))
+      data:
+        kubeconfig: (( base64( asyaml( .imports.kube-apiserver.export.kubeconfig ) ) ))
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: dashboard.gardener.cloud:system:project-member
+        labels:
+          rbac.gardener.cloud/aggregate-to-project-member: "true"
+      rules:
+      - apiGroups:
+        - dashboard.gardener.cloud
+        resources:
+        - terminals
+        verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+
+kustomize:
+  virtual:
+    render:
+      path: (( .settings.repo_path ))
+      kustomization: (( "config/overlay/multi-cluster/virtual-garden" ))
+    apply:
+      kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
+      files:
+        - (( env.GENDIR "/kustomize.virtual.render/manifest.yaml" ))
+  runtime:
+    edit:
+      kustomization: (( "config/overlay/multi-cluster/runtime/manager" ))
+      path: (( .settings.repo_path ))
+      args:
+        - add
+        - secret
+        - kubeconfig
+        - (( "--from-literal=kubeconfig=" asjson( .imports.kube-apiserver.export.kubeconfig ) ))
+        - --type=Opaque
+    render:
+      path: (( env.GENDIR "/kustomize.runtime.edit/edit" ))
+      kustomization: (( "config/overlay/multi-cluster/runtime" ))
+    apply:
+      kubeconfig: (( .landscape.clusters[0].kubeconfig ))
+      files:
+        - (( env.GENDIR "/kustomize.runtime.render/manifest.yaml" ))
+
+settings:
+  namespace: terminal-system
+  kubeconfig_secret: garden-kubeconfig-for-admin
+  repo_path: (( env.GENDIR "/git/repo" ))
+  cert_path: (( repo_path "/config/secret/tls" ))
+
+writefiles:
+  <<: (( &temporary ))
+  cert:
+    crt: (( write( .settings.cert_path "/terminal-controller-manager-tls.pem", .state.cert.value.cert ) ))
+    key: (( write( .settings.cert_path "/terminal-controller-manager-tls-key.pem", .state.cert.value.key ) ))
+
+spec:
+  <<: (( &temporary ))
+  cert:
+    commonName: "terminal-webhook-service.terminal-system.svc.cluster.local"
+    validity: 87600
+    usage:
+      - ServerAuth
+      - ClientAuth
+      - KeyEncipherment
+    hosts:
+      - "terminal-webhook-service"
+      - "terminal-webhook-service.terminal-system"
+      - "terminal-webhook-service.terminal-system.svc"
+      - "terminal-webhook-service.terminal-system.svc.cluster"
+      - "terminal-webhook-service.terminal-system.svc.cluster.local"
+
+state:
+  <<: (( &state(merge none) ))
+  ca: (( utilities.certs.selfSignedCA("ca-gardener-term", false) ))
+  cert: (( utilities.certs.keyCertForCA(spec.cert, ca, false) ))

--- a/components/terminals/export.yaml
+++ b/components/terminals/export.yaml
@@ -1,0 +1,4 @@
+---
+settings: (( &temporary ))
+export:
+  kubeconfig_secret: (( settings.kubeconfig_secret ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -41,6 +41,10 @@
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extensions.git",
           "version": "1.0.4"
+        },
+        "shoot-cert-service": {
+          "repo": "https://github.com/gardener/gardener-extensions.git",
+          "version": "1.0.4"
         }
       }
     },

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -1,11 +1,10 @@
 # Advanced Configuration Options for 'landscape.dashboard'
 
-The `landscape.dashboard` node is entirely optional. There are basically three nodes in it that are evaluated:
+The `landscape.dashboard` node is entirely optional. 
+Whatever is specified for
 - `landscape.dashboard.frontendConfig`
 - `landscape.dashboard.gitHub`
-- `landscape.dashboard.cname`
-
-The contents of the first two will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values.
+will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values.
 
 Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).
 
@@ -25,4 +24,33 @@ With `landscape.dashboard.cname`, you can provide another domain from which the 
 If you specify `landscape.dashboard.cname`, the `domain` field has to exist. A `CNAME` DNS entry will be created for that domain, pointing to the Gardener dashboard domain. This differs from `landscape.domain`, where you enter a base domain for your cluster and the dashboard will be available on a subdomain of that domain - this one will point directly to the dashboard.
 The `dns` field follows the same structure as `landscape.dns`. If the domain is managed by the same account on the same cloud provider as the one given in `landscape.dns`, you can remove the `dns` field completely, in which case it will use the same values as `landscape.dns`.
 
-The given domain will be included in the generated certificate. If you use untrusted certificates (e.g. self-signed or from the letsencrypt staging server) and access the dashboard via the domain given here
+The given domain will be included in the generated certificate. If you use untrusted certificates (e.g. self-signed or from the letsencrypt staging server) and access the dashboard via the domain given here.
+
+
+### landscape.dashboard.terminals
+
+```yaml
+  ...
+  dashboard:
+    ...
+    terminals:
+      active: false
+      cert:
+        email: # email for ACME registration
+        server: "https://acme-v02.api.letsencrypt.org/directory"
+        privateKey: # optional private key for ACME server
+```
+
+Via `landscape.dashboard.terminals.active`, the dashboard terminals can be activated, adding terminals to the dashboard that allow easy access to the base cluster, any shoot, and any seed (if you have sufficient privileges to access the corresponding cluster). By default, the terminals are deactivated.
+
+The terminals need trusted certificates and won't work with self-signed ones. The [shoot-cert-service](https://github.com/gardener/gardener-extensions/tree/master/controllers/extension-shoot-cert-service) is used to generate the certificates. The configuration can be done in the optional `landscape.dashboard.terminals.cert` node:
+- With `email`, you can set the email used for the ACME registration. If not specified, it will default to `landscape.cert-manager.email` or `landscape.identity.users[0].email`, in that order. 
+  - > Using the same email for the cert-manager and the shoot-cert-service can cause problems (duplicate email registration at ACME server), therefore you are advised to use a different email here.
+- `server` specifies the ACME server to use for signing certificates. If not set, it defaults to the server specified in `landscape.cert-manager`.
+  - This field does not allow `live` for a value, as opposed to the `landscape.cert-manager` spec. Defaulting to the server given for the cert-manager will work though, even if that value is set to `live`.
+- If you have a private key for the ACME server, you can specify it at `privateKey`.
+  - If `landscape.dashboard.terminals.cert.server` is not set, this field defaults to `landscape.cert-manager.privateKey`, otherwise it is empty.
+
+Due to technical limitations, some ingresses in shoot will have a `certmanager.k8s.io/cluster-issuer: ...` annotation despite the cert-manager not being deployed on the shoots. To avoid conflicts when valid certificates are needed on a shoot, you can either use the [shoot-cert-service](https://github.com/gardener/gardener-extensions/tree/master/controllers/extension-shoot-cert-service), which is deployed on the shoot, or, if you want to use your own cert-manager deployment, make sure you choose a different name for your clusterissuer(s).
+
+Check out the [terminal-controller-manager](https://github.com/gardener/terminal-controller-manager) for more information on the terminals.


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
⚠️ `sow` version 1.4.0 or higher is required
```
```noteworthy operator
The dashboard terminals have been added to garden-setup. See the [documentation](docs/extended/dashboard.md) for details.
```
```improvement operator
The Gardener extensions now use the `repo` specified in the `dependency-versions.yaml` file.
```