### PR TITLE
use service account kubeconfigs instead of admin kubeconfig

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -137,7 +137,7 @@ landscape:
       repo: https://github.com/gardener/terminal-controller-manager.git
       image_tag: (( valid( tag ) ? tag :~~ ))
       image_repo: (( ~~ ))
-      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.5.0" ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.6.0" ))
     dns-controller:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -15,9 +15,13 @@
 ---
 imports: (( &temporary ))
 landscape: (( &temporary ))
+env: (( &temporary ))
 
 plugins:
-  - helm: dashboard
+  - kubectl: kubectl_sa
+  - helm:
+    - dashboard
+    - spiff
   - kubectl: rbac
   - (( valid( .landscape.dashboard.cname ) ? { "kubectl" = "cname_dnsentry" } :~~ ))
   - -echo: "==================================================================="
@@ -48,7 +52,7 @@ dashboard:
       clientSecret: (( imports.identity.export.dashboardClientSecret ))
     tlsSecretName: (( imports.cert.export.certificate.secret_name ))
     tls: ~
-    kubeconfig: (( asyaml(imports.kube_apiserver.export.kubeconfig) ))
+    kubeconfig: (( format( "((! read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"text\") ))", env.GENDIR, .settings.serviceaccount_name ) ))
     podLabels:
       <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))
       networking.gardener.cloud/to-dns: allowed
@@ -106,7 +110,29 @@ util:
   userbindings: ((|users|->map[users|user|->*spec.subject] ))
 
 settings:
+  serviceaccount_name: gardener-dashboard
   dashboard_url: (( "https://" imports.identity.export.dashboard_dns ))
+
+kubectl_sa:
+  kubeconfig: (( .imports.kube_apiserver.export.kubeconfig ))
+  manifests:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: (( .settings.serviceaccount_name ))
+        namespace: (( .landscape.namespace ))
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: "dashboard.gardener.cloud:admin"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: (( .settings.serviceaccount_name ))
+          namespace: (( .landscape.namespace ))
 
 spec:
   <<: (( &temporary ))

--- a/components/gardener/runtime/deployment.yaml
+++ b/components/gardener/runtime/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   apiserver_token: (( base64_decode( utilities.kubectl.getField( kubeconfig, "secret", apiserver_secret, "{.data.token}")) ))
   controller_secret: (( utilities.kubectl.getField(kubeconfig,"sa","gardener-controller-manager", "{.secrets[0].name}") ))
   controller_token: (( base64_decode( utilities.kubectl.getField( kubeconfig, "secret", controller_secret, "{.data.token}")) ))
-  cluster_endpoint: (( "https://" utilities.kubectl.getField( landscape.clusters.[0].kubeconfig, "svc", "garden-kube-apiserver", "{.metadata.name}:{.spec.ports[0].port}") ))
+  cluster_endpoint: (( imports.kube_apiserver.export.apiserver_url_internal ))
   apiserver_ca: (( base64( imports.kube_apiserver.export.kube_apiserver_ca.cert ) ))
 
 kubeconfig_scheme:

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -237,7 +237,7 @@ gardener:
               retrySyncPeriod: 15s
               concurrentSyncs: 5
               candidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
-        kubeconfig: (( asyaml( imports.kube_apiserver.export.kubeconfig ) ))
+        # kubeconfig: is only needed for the runtime chart and will be added in export step
       deployment:
         virtualGarden:
           clusterIP: (( min_ip(.landscape.clusters.[0].networks.services) + 20 ))

--- a/components/gardener/virtual/export.yaml
+++ b/components/gardener/virtual/export.yaml
@@ -15,8 +15,15 @@
 ---
 gardener: (( &temporary ))
 settings: (( &temporary ))
+env: (( &temporary ))
 export:
   gardener:
     seedCandidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
-    values: (( .gardener.values ))
+    values:
+      <<: (( .gardener.values ))
+      global:
+        <<: (( .gardener.values.global ))
+        scheduler:
+          <<: (( .gardener.values.global.scheduler ))
+          kubeconfig: (( read( env.GENDIR "/kubectl_apply/sa_gardener-scheduler.kubeconfig", "text" ) ))
   dns_credentials: (( .settings.dns_credentials ))

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -23,6 +23,7 @@ plugins:
 settings:
   apiserver_dns: (( "api." imports.ingress_controller.export.ingress_domain ))
   gardener_dns: (( "gardener." imports.ingress_controller.export.ingress_domain ))
+  apiserver_url_internal: (( "https://" .kubeapiserver.serviceName "." .kubeapiserver.namespace ".svc:443" ))
   
 spec:
   <<: (( &temporary ))
@@ -86,7 +87,7 @@ kubeapiserver:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   source: chart
   name: "garden-kube-apiserver"
-  namespace: "garden"
+  namespace: (( .landscape.namespace ))
   serviceName: (( name ))
   values:
     images:

--- a/components/kube-apiserver/export.yaml
+++ b/components/kube-apiserver/export.yaml
@@ -36,6 +36,7 @@ export:
   gardener_dns: (( .settings.gardener_dns ))
   apiserver_dns: (( .settings.apiserver_dns ))
   apiserver_url: (( "https://" apiserver_dns ))
+  apiserver_url_internal: (( .settings.apiserver_url_internal ))
   kube_apiserver_ca: (( .state.kube_apiserver_ca.value ))
   kubeconfig: (( parse(base64_decode(exec( temp.command ))) || "" ))
 

--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -4,8 +4,52 @@ landscape: (( &temporary ))
 env: (( &temporary ))
 
 plugins:
+  - kubectl: kubectl_sa
   - kubectl_patch
-  - helm
+  - helm:
+    - helm
+    - spiff
+
+kubectl_sa:
+  kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
+  manifests:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: (( .settings.serviceaccount_name ))
+        namespace: (( .landscape.namespace ))
+        labels:
+          app: gardener
+          role: metrics-exporter
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: garden.sapcloud.io:metrics-exporter
+      rules:
+      - apiGroups:
+        - garden.sapcloud.io
+        - core.gardener.cloud
+        resources:
+        - shoots
+        - seeds
+        - projects
+        - plants
+        verbs:
+        - get
+        - watch
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: garden.sapcloud.io:metrics-exporter
+      subjects:
+      - kind: ServiceAccount
+        name: (( .settings.serviceaccount_name ))
+        namespace: (( .landscape.namespace ))
+      roleRef:
+        kind: ClusterRole
+        name: garden.sapcloud.io:metrics-exporter
+        apiGroup: rbac.authorization.k8s.io
 
 kubectl_patch:
   kubeconfig: (( .landscape.clusters[0].kubeconfig ))
@@ -25,10 +69,11 @@ helm:
     image:
       repository: (( .landscape.versions.monitoring.gardener-metrics-exporter.image_repo || ~~ ))
       tag: (( .landscape.versions.monitoring.gardener-metrics-exporter.image_tag || ~~ ))
-    kubeconfig: (( asyaml( .imports.kube-apiserver.export.kubeconfig ) ))
+    kubeconfig: (( format( "((! read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"text\") ))", env.GENDIR, .settings.serviceaccount_name ) ))
 
 settings:
   dashboard_path_prefix: (( env.GENDIR "/git/repo/dashboards/" ))
+  serviceaccount_name: gardener-metrics-exporter
   excluded_dashboards:
     - shoot-state-overview-dashboard.json
 

--- a/components/terminals/action
+++ b/components/terminals/action
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Takes a kubeconfig file and creates a secret manifest for it. The manifest is not applied.
+create_kubeconfig_secret()
+{
+  PLUGIN_setup "$2" create_kubeconfig_secret
+  getRequiredValue name "name" PLUGINCONFIGJSON
+  getRequiredValue namespace "namespace" PLUGINCONFIGJSON
+  getRequiredValue kubeconfig_path "kubeconfig_path" PLUGINCONFIGJSON
+  getValue write_to "write_to" PLUGINCONFIGJSON
+
+  local kubeconfig="Zm9v"
+  if [ "$1" = "deploy" ]; then
+    if [[ ! -f "$kubeconfig_path" ]]; then
+      fail "kubeconfig not found at path '$kubeconfig_path'"
+    fi
+    kubeconfig=$(cat "$kubeconfig_path" | base64 | tr -d \\n)
+  fi
+
+  local secret_path="${write_to:-"$dir/secret_$name.yaml"}"
+  verbose "Writing kubeconfig secret to '$secret_path'"
+  cat > "$secret_path" << EOF
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: $name
+  namespace: $namespace
+data:
+  kubeconfig: $kubeconfig
+EOF
+}

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -8,23 +8,34 @@ plugins:
   - pinned:
     - kustomize: kustomize.virtual.render
     - kubectl: kustomize.virtual.apply
-  - kubectl
   - pinned:
-    - kustomize-edit: kustomize.runtime.edit
+    - kubectl: kubectl_sa # create serviceaccount and clusterrole
+    - create_kubeconfig_secret: kcfg_admin # create secret manifest for admin kubeconfig
+    - create_kubeconfig_secret: kcfg_sa # create secret manifest for sa kubeconfig (directly overrides checked-out charts)
+    - kubectl: kubectl_admin_kubeconfig # apply admin kubeconfig secret
+  - pinned:
     - kustomize: kustomize.runtime.render
     - kubectl: kustomize.runtime.apply
 
-kubectl:
+kcfg_admin:
+  name: (( settings.kubeconfig_secret_name ))
+  namespace: (( .landscape.namespace ))
+  kubeconfig_path: (( .settings.kubeconfig_path ))
+
+kcfg_sa:
+  name: kubeconfig
+  namespace: terminal-system
+  kubeconfig_path: (( .settings.kubeconfig_secret_path_sa ))
+  write_to: (( .settings.repo_path "/config/overlay/multi-cluster/runtime/manager/kubeconfig-secret.yaml" ))
+
+kubectl_sa:
   kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
   manifests:
     - apiVersion: v1
-      kind: Secret
-      type: Opaque
+      kind: ServiceAccount
       metadata:
-        name: (( settings.kubeconfig_secret ))
-        namespace: (( .landscape.namespace ))
-      data:
-        kubeconfig: (( base64( asyaml( .imports.kube-apiserver.export.kubeconfig ) ) ))
+        name: default
+        namespace: terminal-system
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -46,6 +57,11 @@ kubectl:
         - update
         - watch
 
+kubectl_admin_kubeconfig:
+  kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
+  files:
+    - (( .settings.kubeconfig_secret_path_admin ))
+
 kustomize:
   virtual:
     render:
@@ -56,17 +72,8 @@ kustomize:
       files:
         - (( env.GENDIR "/kustomize.virtual.render/manifest.yaml" ))
   runtime:
-    edit:
-      kustomization: (( "config/overlay/multi-cluster/runtime/manager" ))
-      path: (( .settings.repo_path ))
-      args:
-        - add
-        - secret
-        - kubeconfig
-        - (( "--from-literal=kubeconfig=" asjson( .imports.kube-apiserver.export.kubeconfig ) ))
-        - --type=Opaque
     render:
-      path: (( env.GENDIR "/kustomize.runtime.edit/edit" ))
+      path: (( .settings.repo_path ))
       kustomization: (( "config/overlay/multi-cluster/runtime" ))
     apply:
       kubeconfig: (( .landscape.clusters[0].kubeconfig ))
@@ -74,13 +81,17 @@ kustomize:
         - (( env.GENDIR "/kustomize.runtime.render/manifest.yaml" ))
 
 settings:
-  namespace: terminal-system
-  kubeconfig_secret: garden-kubeconfig-for-admin
-  repo_path: (( env.GENDIR "/git/repo" ))
-  cert_path: (( repo_path "/config/secret/tls" ))
+  namespace: terminal-system                                                                              # terminal controller manager namespace
+  kubeconfig_secret_name: garden-kubeconfig-for-admin                                                     # name of admin kubeconfig secret
+  kubeconfig_path: (( env.GENDIR "/" kubeconfig_secret_name ".kubeconfig" ))                              # path to admin kubeconfig
+  kubeconfig_secret_path_sa: (( env.GENDIR "/kubectl_sa/sa_default.kubeconfig" ))                         # path to secret manifest for sa kubeconfig
+  kubeconfig_secret_path_admin: (( env.GENDIR "/kcfg_admin/secret_" kubeconfig_secret_name ".yaml" ))     # path to secret manifest for admin kubeconfig
+  repo_path: (( env.GENDIR "/git/repo" ))                                                                 # path to checked-out git repo for easy access
+  cert_path: (( repo_path "/config/secret/tls" ))                                                         # path to tls folder in checked-out git repo
 
 writefiles:
   <<: (( &temporary ))
+  admin_kubeconfig: (( write( .settings.kubeconfig_path, .imports.kube-apiserver.export.kubeconfig ) )) # 'copy' admin kubeconfig to GENDIR
   cert:
     crt: (( write( .settings.cert_path "/terminal-controller-manager-tls.pem", .state.cert.value.cert ) ))
     key: (( write( .settings.cert_path "/terminal-controller-manager-tls-key.pem", .state.cert.value.key ) ))

--- a/components/terminals/export.yaml
+++ b/components/terminals/export.yaml
@@ -1,4 +1,4 @@
 ---
 settings: (( &temporary ))
 export:
-  kubeconfig_secret: (( settings.kubeconfig_secret ))
+  kubeconfig_secret: (( settings.kubeconfig_secret_name ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of providing the admin kubeconfig to each component that needs access to the 'virtual' kube-apiserver, these components now create a service account and use a kubeconfig generated from the service account's token, if possible.

**Which issue(s) this PR fixes**:
#115 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `dashboard`, `gardener`, `gardener-metrics-exporter`, and `terminals` components now use specific kubeconfigs generated from their own respective service account to access the virtual kube-apiserver (instead of the admin kubeconfig).
```
```improvement operator
Upgrade terminal-controller-manager to `0.6.0`
```