### PR TITLE
add 'to-inside' network policy to allow dashboard to communicate with seed apiservers

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -60,6 +60,7 @@ dashboard:
       networking.gardener.cloud/to-identity: allowed
       networking.gardener.cloud/to-ingress: allowed
       networking.gardener.cloud/to-world: allowed
+      networking.gardener.cloud/to-inside: allowed
     gitHub: (( .landscape.dashboard.gitHub || ~~ ))
     frontendConfig:
       <<: (( .landscape.dashboard.frontendConfig || ~ ))

--- a/components/network-policies/manifests/to-inside.yaml
+++ b/components/network-policies/manifests/to-inside.yaml
@@ -1,0 +1,23 @@
+# Allows outgoing traffic to private networks.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: to-inside
+  namespace: (( landscape.namespace ))
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-inside: allowed
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 192.168.0.0/16      # private networks (RFC1918)
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/8          # private networks (RFC1918)
+  - to:
+    - ipBlock:
+        cidr: 172.16.0.0/12       # private networks (RFC1918)


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add a network policy allowing outgoing traffic from the dashboard pod to private networks. This fixes a problem that might prevent the dashboard from talking to the seeds' apiservers.
```
