### PR TITLE
use internal url for virtual cluster where possible

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -52,7 +52,7 @@ dashboard:
       clientSecret: (( imports.identity.export.dashboardClientSecret ))
     tlsSecretName: (( imports.cert.export.certificate.secret_name ))
     tls: ~
-    kubeconfig: (( format( "((! read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"text\") ))", env.GENDIR, .settings.serviceaccount_name ) ))
+    kubeconfig: (( format( "((! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
     podLabels:
       <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))
       networking.gardener.cloud/to-dns: allowed

--- a/components/kube-apiserver/export.yaml
+++ b/components/kube-apiserver/export.yaml
@@ -39,7 +39,23 @@ export:
   apiserver_url_internal: (( .settings.apiserver_url_internal ))
   kube_apiserver_ca: (( .state.kube_apiserver_ca.value ))
   kubeconfig: (( parse(base64_decode(exec( temp.command ))) || "" ))
+  kubeconfig_internal_merge_snippet: (( .files.kubeconfig_internal_merge_snippet.data ))
 
 files:
   kubeconfig:
     data: (( asyaml(export.kubeconfig) ))
+  kubeconfig_internal_merge_snippet:
+    data: (( .kubeconfig_internal_merge.snippet ))
+
+kubeconfig_internal_merge:
+  <<: (( &temporary ))
+  snippet: (( replace( raw_snippet, "internal-domain-here", .settings.apiserver_url_internal ) ))
+  raw_snippet: |
+    ---
+    <<: (( &template ))
+    apiVersion:
+    kind:
+    current-context:
+    contexts:
+    clusters: (( merge none // [ stub(clusters)[0] { "cluster" = merge( stub(clusters)[0].cluster, { "server" = "internal-domain-here" } ) } ] ))
+    users:

--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -69,7 +69,7 @@ helm:
     image:
       repository: (( .landscape.versions.monitoring.gardener-metrics-exporter.image_repo || ~~ ))
       tag: (( .landscape.versions.monitoring.gardener-metrics-exporter.image_tag || ~~ ))
-    kubeconfig: (( format( "((! read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"text\") ))", env.GENDIR, .settings.serviceaccount_name ) ))
+    kubeconfig: (( format( "((! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
 
 settings:
   dashboard_path_prefix: (( env.GENDIR "/git/repo/dashboards/" ))

--- a/components/terminals/action
+++ b/components/terminals/action
@@ -21,17 +21,17 @@ create_kubeconfig_secret()
   getRequiredValue namespace "namespace" PLUGINCONFIGJSON
   getRequiredValue kubeconfig_path "kubeconfig_path" PLUGINCONFIGJSON
   getValue write_to "write_to" PLUGINCONFIGJSON
+  getValue server "server" PLUGINCONFIGJSON
 
   local kubeconfig="Zm9v"
   if [ "$1" = "deploy" ]; then
     if [[ ! -f "$kubeconfig_path" ]]; then
       fail "kubeconfig not found at path '$kubeconfig_path'"
     fi
-    kubeconfig=$(cat "$kubeconfig_path" | base64 | tr -d \\n)
+    kubeconfig=$(cat "$kubeconfig_path" | replace_server "$server" | base64 | tr -d \\n)
   fi
 
-  local secret_path="${write_to:-"$dir/secret_$name.yaml"}"
-  verbose "Writing kubeconfig secret to '$secret_path'"
+  local secret_path="$dir/secret_$name.yaml"
   cat > "$secret_path" << EOF
 apiVersion: v1
 kind: Secret
@@ -42,4 +42,21 @@ metadata:
 data:
   kubeconfig: $kubeconfig
 EOF
+
+  if [[ -n ${write_to:-""} ]]; then
+    verbose "Writing kubeconfig secret to '$write_to'"
+    cp -f "$secret_path" "$write_to"
+  fi
+}
+
+replace_server()
+{
+  if [[ -n ${1:-""} ]]; then
+    # convert to json using spiff, replace server url, convert back to yaml
+    verbose "Replacing server url with '$1' ..."
+    spiff merge --json - | jq -r ".clusters[0].server = \"$1\"" | spiff merge -
+  else
+    # just pipe input through without modifying it
+    cat -
+  fi
 }

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -27,6 +27,7 @@ kcfg_sa:
   namespace: terminal-system
   kubeconfig_path: (( .settings.kubeconfig_secret_path_sa ))
   write_to: (( .settings.repo_path "/config/overlay/multi-cluster/runtime/manager/kubeconfig-secret.yaml" ))
+  server: (( .imports.kube-apiserver.export.apiserver_url_internal ))
 
 kubectl_sa:
   kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Components that get a kubeconfig for the virtual kube-apiserver now use the internal url, if possible.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Components now use the internal url to connect to the 'virtual' kube-apiserver.
```
