### PR TITLE
make shoot default networks configurable via acre.yaml

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -369,6 +369,11 @@ validation:
       - ["mapfield", "type", ["valueset", (( keys( types.iaas ) ))]]
       - ["mapfield", "mode", ["valueset", ["seed", "profile", "cloudprofile", "soil"]]]
       - - optionalfield
+        - shootDefaultNetworks
+        - - and
+          - ["mapfield", "pods", ["cidr"]]
+          - ["mapfield", "services", ["cidr"]]
+      - - optionalfield
         - credentials
         - (( types.iaas[values.type].credentials ))
       - <<: (( types.iaas[values.type].config ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -64,9 +64,7 @@ seedSpec:
     nodes: (( configValues.seed.networks.nodes ))
     pods: (( configValues.seed.networks.pods ))
     services: (( configValues.seed.networks.services ))
-    shootDefaults:
-      pods: 100.96.0.0/11
-      services: 100.64.0.0/13
+    shootDefaults: (( configValues.seed.shootDefaultNetworks || { "pods" = "100.96.0.0/11", "services" = "100.64.0.0/13" } ))
   taints: (( configValues.config.mode == "soil" ? [{ "key" = "seed.gardener.cloud/invisible" }] :~~ ))
 
 gardenletBootstrapKubeconfig:

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -50,4 +50,5 @@ providerconfig:
   seed:
     ingressdomain: (( "ingress." name "." .landscape.domain ))
     networks: (( {"nodes" = v.cluster.networks.nodes, "pods" = v.cluster.networks.pods, "services" = v.cluster.networks.services} ))
+    shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
   secretname: (( name "-" v.mode ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -58,6 +58,7 @@ providerconfig:
   seed:
     ingressdomain: (( name "." .imports.ingress_dns.export.ingress_domain ))
     networks: (( v.cluster.networks || landscape.clusters.[0].networks ))
+    shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
   secretname: (( name "-" v.mode ))
 
 renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -6,6 +6,9 @@ iaas:
     type: <gcp|aws|azure|openstack>              # iaas provider
     mode: <seed|soil>                            # optional, defaults to 'seed'
     cloudprofile: <name of cloudprofile>         # optional, will deploy its own cloudprofile if not specified
+    shootDefaultNetworks:                        # optional, overwrites defaults of .spec.networks.shootDefaults in the seed manifest
+      pods: 100.96.0.0/11
+      services: 100.64.0.0/13
     region: <major region>-<minor region>        # region for initial seed
     zones:                                       # remove zones block for Azure
       - <major region>-<minor region>-<zone>     # example: europe-west1-b
@@ -32,6 +35,7 @@ iaas:
   - name:                                        # see above
     mode: <seed|cloudprofile|profile|inactive>   # what should be deployed
     type: <gcp|aws|azure|openstack>              # see above
+    shootDefaultNetworks:                        # see above
     region: <major region>-<minor region>        # region for seed
     zones:                                       # remove zones block for Azure
       - <major region>-<minor region>-<zone>     # example: europe-west1-b
@@ -77,6 +81,7 @@ Cloudprofiles are created first, before any seed. Thus, entries of `landscape.ia
       - name:                                    # max. 10 characters
         type: <gcp|aws|azure|openstack>
         mode: <seed|soil>                        # NOT optional for nested entries
+        shootDefaultNetworks:                    # see above
         region: <major region>-<minor region>
         zones:
           - <major region>-<minor region>-<zone>


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
#141 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The shoot default networks of a seed (`spec.networks.shootDefaults` in the seed manifest) can now be overwritten by setting `shootDefaultNetworks` in that seed's iaas entry in the acre.yaml.
```
