### PR TITLE
Update DNS version to fix issue with ACME challenge

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.7.4"
+          "version": "v0.7.5"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extensions.git",


### PR DESCRIPTION
**What this PR does / why we need it**:
DNS 0.7.4 contains an error if an DNS entry only contains text, e.g. for the ACME challenge

**Which issue(s) this PR fixes**:
https://github.com/gardener/external-dns-management/pull/53

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Upgrade dns-controller-manager to `v0.7.5`
```
