### PR TITLE
activate logging feature gate for seed clusters

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -168,7 +168,8 @@ gardenletSpec:
           resourceLock: configmaps
         logLevel: info
         kubernetesLogLevel: 0
-        featureGates: {}
+        featureGates:
+          Logging: true
         seedConfig:
           metadata:
             name: (( configValues.name ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Activates the logging feature gate for seed clusters.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `Logging` feature gate on the gardenlet is now activated.
```
