### PR TITLE
replace "helm upgrade" calls with "helm template" and "kubectl apply"

### DIFF
--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -27,7 +27,11 @@ caSpec:
 plugins:
   - kubectl: namespace
   - kubectl: crds
-  - helm
+  - pinned:
+    - helm:
+      - helm
+      - template
+    - kubectl: helm
   - -echo: (( .settings.self-signed ? ( .settings.ca.given ? "Using provided CA" :"Using self-signed CA" ) :"Using ACME server at " .caSpec.url ))
   - kubectl: issuer
 
@@ -117,6 +121,8 @@ servers:
 
 helm:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "helm/rendered_charts.yaml"
   source: "chart-checkout/charts/cert-manager"
   name: cert-manager
   namespace: (( .namespace.name ))

--- a/components/cert-manager/solver/deployment.yaml
+++ b/components/cert-manager/solver/deployment.yaml
@@ -8,10 +8,16 @@ plugins_self_signed:
   - -echo: "Using self-signed certificates, no solver deployment necessary."
 
 plugins_not_self_signed:
-  - helm
+  - pinned:
+    - helm:
+      - helm
+      - template
+    - kubectl: helm
 
 helm:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "helm/rendered_charts.yaml"
   source: "git/repo/charts/certificate-dns-bridge"
   name: certificate-dns-bridge
   namespace: (( imports.cert-controller.export.namespace ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -19,9 +19,12 @@ env: (( &temporary ))
 
 plugins:
   - kubectl: kubectl_sa
-  - helm:
-    - dashboard
-    - spiff
+  - pinned:
+    - helm:
+      - dashboard
+      - spiff
+      - template
+    - kubectl: dashboard
   - kubectl: rbac
   - (( valid( .landscape.dashboard.cname ) ? { "kubectl" = "cname_dnsentry" } :~~ ))
   - -echo: "==================================================================="
@@ -32,6 +35,8 @@ dashboard_version: (( &temporary ( .landscape.versions.dashboard ) ))
 
 dashboard:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "dashboard/rendered_charts.yaml"
   source: "git/repo/charts/gardener-dashboard"
   name: "dashboard"
   namespace: (( .landscape.namespace ))

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -24,10 +24,16 @@ temp:
   dir: (( __ctx.DIR "/provider/" config.type ))
 
 plugins:
-  - helm:
-    - etcd.main
-  - helm:
-    - etcd.events
+  - pinned:
+    - helm:
+      - etcd.main
+      - template
+    - kubectl: etcd.main
+  - pinned:
+    - helm:
+      - etcd.events
+      - template
+    - kubectl: etcd.events
 
 spec:
   <<: (( &temporary ))
@@ -69,6 +75,8 @@ state:
 etcd:
   main:
     kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+    files:
+      - "etcd.main/rendered_charts.yaml"
     source: chart
     name: garden-etcd-main
     namespace: (( .landscape.namespace ))
@@ -102,6 +110,8 @@ etcd:
 
   events:
     kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+    files:
+      - "etcd.events/rendered_charts.yaml"
     source: chart
     name: garden-etcd-events
     namespace: (( .landscape.namespace ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -194,6 +194,8 @@ pluginSpecs:
           name: (( landscape.namespace ))
   gardenlet:
     kubeconfig: (( configValues.kubeconfigs.seed ))
+    files:
+      - (( "renderedPluginSpecs[" id "].gardenlet/rendered_charts.yaml" ))
     source: "git/repo/charts/gardener/gardenlet/charts/runtime"
     name: gardenlet
     namespace: garden

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -25,7 +25,11 @@ pluginTemplate:
   - <<: (( &temporary &template ))
   - kubectl: (( "renderedPluginSpecs[" id "].deploySecrets" ))
   - (( valid( renderedPluginSpecs[id].namespace ) ? { "kubectl" = "renderedPluginSpecs[" id "].namespace" } :~~ ))
-  - helm: (( "renderedPluginSpecs[" id "].gardenlet" ))
+  - pinned:
+    - helm:
+      - (( "renderedPluginSpecs[" id "].gardenlet" ))
+      - template
+    - kubectl: (( "renderedPluginSpecs[" id "].gardenlet" ))
   - seed-ready: (( "renderedPluginSpecs[" id "].seedReady" ))
   - delete: (( "renderedPluginSpecs[" id "].deleteSeed" ))
   - delete: (( "renderedPluginSpecs[" id "].deleteBootstrapToken" ))
@@ -35,7 +39,7 @@ temp:
   bootstrapNamePrefix: (( &temporary ( |x|-> replace( replace( substr( x, 0, 3 ), "-", "7" ), ".", "0" ) ) ))
 bootstrapTokens: (( sum[.landscape.iaas_shooted_seeds|{}|s,elem|-> s { elem.name = { "id" = temp.bootstrapNamePrefix( elem.name ) rand( "a-z0-9", 3 ), "secret" = temp.bootstrapNamePrefix( elem.name ) rand( "a-z0-9", 13 ) } }] ))
 
-renderedPluginSpecs: (( sum[.landscape.iaas_shooted_seeds|[]|s,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))
+renderedPluginSpecs: (( sum[.landscape.iaas_shooted_seeds|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))
 
 providerconfig:
   <<: (( &template &temporary ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -25,7 +25,11 @@ pluginTemplate:
   - <<: (( &temporary &template ))
   - kubectl: (( "renderedPluginSpecs[" id "].deploySecrets" ))
   - (( valid( renderedPluginSpecs[id].namespace ) ? { "kubectl" = "renderedPluginSpecs[" id "].namespace" } :~~ ))
-  - helm: (( "renderedPluginSpecs[" id "].gardenlet" ))
+  - pinned:
+    - helm:
+      - (( "renderedPluginSpecs[" id "].gardenlet" ))
+      - template
+    - kubectl: (( "renderedPluginSpecs[" id "].gardenlet" ))
   - seed-ready: (( "renderedPluginSpecs[" id "].seedReady" ))
   - delete: (( "renderedPluginSpecs[" id "].deleteSeed" ))
   - delete: (( "renderedPluginSpecs[" id "].deleteBootstrapToken" ))
@@ -61,4 +65,4 @@ providerconfig:
     shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
   secretname: (( name "-" v.mode ))
 
-renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))
+renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/components/gardener/runtime/deployment.yaml
+++ b/components/gardener/runtime/deployment.yaml
@@ -59,8 +59,11 @@ kubeconfigs:
     config: (( *kubeconfig_scheme ))
 
 plugins:
-  - helm:
-    - gardener
+  - pinned:
+    - helm:
+      - gardener
+      - template
+    - kubectl: gardener
   - gardenready
   - shoot-check
 
@@ -73,6 +76,8 @@ gardenready:
 gardener:
   <<: (( imports.gardener_virtual.export.gardener ))
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "gardener/rendered_charts.yaml"
   source: "git/repo/charts/gardener/controlplane/charts/runtime"
   values: (( merge(.imports.gardener_virtual.export.gardener.values, spec) ))
   name: gardener

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -18,7 +18,11 @@ landscape: (( &temporary ))
 utilities: (( &temporary ))
 
 plugins:
-  - helm: identity
+  - pinned:
+    - helm:
+      - identity
+      - template
+    - kubectl: identity
 
 identity_version: (( &temporary ( .landscape.versions.identity ) ))
 
@@ -53,6 +57,8 @@ state:
 
 identity:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "identity/rendered_charts.yaml"
   source: "git/repo/charts/identity"
   name: "identity"
   namespace: (( .landscape.namespace ))

--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -17,13 +17,19 @@ landscape: (( &temporary ))
 imports: (( &temporary ))
 
 plugins:
-  - helm: ingresscontroller
+  - pinned:
+    - helm:
+      - ingresscontroller
+      - template
+    - kubectl: ingresscontroller
 
 settings:
   ingress_domain: (( "ing." landscape.domain ))
 
 ingresscontroller:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "ingresscontroller/rendered_charts.yaml"
   source: chart
   name: "nginx-ingress-controller"
   namespace: "kube-system" # for yet unknown reason, only kube-system works ...

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -18,7 +18,11 @@ imports: (( &temporary ))
 utilities: (( &temporary ))
 
 plugins:
-  - helm: kubeapiserver
+  - pinned:
+    - helm:
+      - kubeapiserver
+      - template
+    - kubectl: kubeapiserver
 
 settings:
   apiserver_dns: (( "api." imports.ingress_controller.export.ingress_domain ))
@@ -85,6 +89,8 @@ state:
 
 kubeapiserver:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "kubeapiserver/rendered_charts.yaml"
   source: chart
   name: "garden-kube-apiserver"
   namespace: (( .landscape.namespace ))

--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -6,9 +6,12 @@ env: (( &temporary ))
 plugins:
   - kubectl: kubectl_sa
   - kubectl_patch
-  - helm:
-    - helm
-    - spiff
+  - pinned:
+    - helm:
+      - helm
+      - spiff
+      - template
+    - kubectl: helm
 
 kubectl_sa:
   kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
@@ -62,6 +65,8 @@ kubectl_patch:
 
 helm:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  files:
+    - "helm/rendered_charts.yaml"
   source: "git/repo/charts/gardener-metrics-exporter"
   name: gardener-metrics-exporter
   namespace: (( .landscape.namespace ))


### PR DESCRIPTION
The helm3 "upgrade" command is flakey and sometimes fails for unknown reasons.
Since the "kubectl" plugin of sow does a similar kind of state handling, not much functionality is lost by using helm only to render the charts.

**Which issue(s) this PR fixes**:
#170 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Instead of using `helm upgrade` to deploy helm charts, helm is now only used to render the charts and they are then applied using the `kubectl` plugin. 
```
```action operator
⚠️ `sow` version `2.1.0` or higher is required.
```
```action operator
⚠️ Do NOT deploy over an existing Gardener landscape that was set up with an older version of garden-setup. Multiple plugin calls have been modified/replaced and `sow`'s state handling might produce unwanted effects trying to upgrade an existing landscape.
```