### PR TITLE
update dashboard clusterrolebindings and add identity documentation

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -158,7 +158,7 @@ rbac:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: garden.sapcloud.io:system:project-creation
+        name: gardener.cloud:system:project-creation
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -167,8 +167,7 @@ rbac:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        annotations:
-        name: garden.sapcloud.io:system:administrators
+        name: gardener.cloud:system:administrators
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole

--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -1,0 +1,45 @@
+# Advanced Configuration Options for 'landscape.identity'
+
+The Gardener dashboard uses [dex](https://github.com/dexidp/dex) for identity management. Users can be specified in the `acre.yaml` file in two different ways, which are explained below. It is possible to combine both variants by specifying `landscape.identity.users` and `landscape.identity.connectors`.
+
+#### Privileges
+
+The `dashboard` component deploys two `ClusterRoleBinding`s for privileges (both binding to the `ClusterRole` with the same name, respectively):
+- membership in `gardener.cloud:system:project-creation` allows a user to create projects (and thus clusters).
+- membership in `gardener.cloud:system:administrators` grants a user operator privileges, providing access to all projects and clusters.
+  - :warning: This means that the user also has access to all infrastructure credentials!
+
+Of the variants below,
+- variant 1 adds each user to both groups, thus granting admin privileges
+- variant 2 doesn't add users to any group, thus granting no privileges
+
+#### Variant 1: hard-coded users
+```yaml
+  identity:
+    users:
+      - email: "administrator@example.com"
+        username: "Admin"
+        password: "myTotallySafePassword#111"
+        # hash: instead of a clear-text password, also a bcrypted hash is possible
+```
+In `landscape.identity.users`, a list of hard-coded users can be specified. They will be able to login into the dashboard using the email and password. 
+
+
+#### Variant 2: OIDC connector
+```yaml
+  identity:
+    connectors:
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: $GITHUB_CLIENT_ID
+          clientSecret: $GITHUB_CLIENT_SECRET
+          redirectURI: http://example.com/oidc/callback
+          orgs:
+          - name: my-gardener-users
+          teamNameField: slug
+```
+In addition to providing a list of hard-coded users, it is also possible to connect dex to another identity provider (e.g. GitHub, SAML, ...). The request will then be forwarded and handled by the specified IDP.
+
+For a list of possible connectors and how to configure them, please check the documentation at https://github.com/dexidp/dex/tree/master/Documentation/connectors.


### PR DESCRIPTION
Adapted dashboard `ClusterRoleBinding`s  to `gardener.cloud` and added advanced documentation for identity component.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added advanced documentation for `identity` component.
```
```improvement operator
The dashboard's `ClusterRoleBinding`s are now prefixed with `gardener.cloud` instead of the old `garden.sapcloud.io`.
```
