### PR TITLE
revert workaround from #180

### DIFF
--- a/components/cert-manager/solver/deployment.yaml
+++ b/components/cert-manager/solver/deployment.yaml
@@ -11,8 +11,8 @@ plugins_not_self_signed:
   - pinned:
     - helm:
       - helm
-      # - template
-    # - kubectl: helm
+      - template
+    - kubectl: helm
 
 helm:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the workaround from https://github.com/gardener/garden-setup/pull/180

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The temporary workaround from [#180](https://github.com/gardener/garden-setup/pull/180) has been reverted.
```
```action operator
⚠️ `sow` version `2.2.0` or higher is required
```
