### PR TITLE
minor updates

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -140,7 +140,7 @@ landscape:
       <<: (( merge ))
       repo: https://github.com/gardener/terminal-controller-manager.git
       image_tag: (( valid( tag ) ? tag :~~ ))
-      image_repo: (( ~~ ))
+      image_repo: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.8.0" ))
     dns-controller:
       <<: (( merge ))

--- a/components/gardencontent/seeds/manifests/shoot_manifest.yaml
+++ b/components/gardencontent/seeds/manifests/shoot_manifest.yaml
@@ -3,9 +3,8 @@ kind: Shoot
 metadata:
   name: (( values.values.name ))
   namespace: (( values.values.namespace ))
-  annotations:
-    garden.sapcloud.io/purpose: infrastructure
 spec:
+  purpose: production # 'infrastructure' is only possible for shoots in the 'garden' namespace
   secretBindingName: (( values.values.secretbinding ))
   cloudProfileName: (( values.values.cloudprofile ))
   seedName: (( values.values.seed ))

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -14,6 +14,7 @@ plugins:
     - create_kubeconfig_secret: kcfg_sa # create secret manifest for sa kubeconfig (directly overrides checked-out charts)
     - kubectl: kubectl_admin_kubeconfig # apply admin kubeconfig secret
   - pinned:
+    - kustomize-edit: kustomize.runtime.edit
     - kustomize: kustomize.runtime.render
     - kubectl: kustomize.runtime.apply
 
@@ -67,15 +68,22 @@ kustomize:
   virtual:
     render:
       path: (( .settings.repo_path ))
-      kustomization: (( "config/overlay/multi-cluster/virtual-garden" ))
+      kustomization: "config/overlay/multi-cluster/virtual-garden"
     apply:
       kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
       files:
         - (( env.GENDIR "/kustomize.virtual.render/manifest.yaml" ))
   runtime:
-    render:
+    edit:
       path: (( .settings.repo_path ))
-      kustomization: (( "config/overlay/multi-cluster/runtime" ))
+      kustomization: "config/manager"
+      args:
+        - set
+        - image
+        - (( "controller=" .landscape.versions.terminal-controller-manager.image_repo ":" ( .landscape.versions.terminal-controller-manager.image_tag || "latest" ) ))
+    render:
+      path: (( env.GENDIR "/kustomize.runtime.edit/edit" ))
+      kustomization: "config/overlay/multi-cluster/runtime"
     apply:
       kubeconfig: (( .landscape.clusters[0].kubeconfig ))
       files:

--- a/docs/extended/README.md
+++ b/docs/extended/README.md
@@ -7,4 +7,5 @@ This document links to all advanced configuration pages for a better overview.
 - [landscape.gardener](gardener.md)
 - [landscape.cert-manager](cert-manager.md)
 - [landscape.monitoring](monitoring.md)
+- [landscape.identity](identity.md)
 - [installation handler](installation-handler.md)


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shooted seeds have now the purpose set to `production`. The old annotation has been removed as it is deprecated, unfortunately the new way allows the purpose `infrastructure` only for shoots in the `garden` namespace, which is not possible in garden-setup.
```
```improvement operator
The image version of the terminal-controller-manager is now correctly transported into the kustomize charts.
```
```improvement operator
A link to the extended `identity` documentation has been added to the extended docs overview page.
```
