### PR TITLE
Fix deletion without 'gen' folder

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -18,13 +18,14 @@ landscape: (( &temporary ))
 env: (( &temporary ))
 
 plugins:
-  - kubectl: kubectl_sa
   - pinned:
-    - helm:
-      - dashboard
-      - spiff
-      - template
-    - kubectl: dashboard
+    - kubectl: kubectl_sa
+    - pinned:
+      - helm:
+        - dashboard
+        - spiff
+        - template
+      - kubectl: dashboard
   - kubectl: rbac
   - (( valid( .landscape.dashboard.cname ) ? { "kubectl" = "cname_dnsentry" } :~~ ))
   - -echo: "==================================================================="

--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -4,14 +4,15 @@ landscape: (( &temporary ))
 env: (( &temporary ))
 
 plugins:
-  - kubectl: kubectl_sa
-  - kubectl_patch
   - pinned:
-    - helm:
-      - helm
-      - spiff
-      - template
-    - kubectl: helm
+    - kubectl: kubectl_sa
+    - kubectl_patch
+    - pinned:
+      - helm:
+        - helm
+        - spiff
+        - template
+      - kubectl: helm
 
 kubectl_sa:
   kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))


### PR DESCRIPTION
**What this PR does / why we need it**:
The change that switched from using the admin kubeconfig for the virtual cluster to using component specific kubeconfigs generated from serviceaccounts introduced a bug that prevents a landscape from being deleted if the `gen` folder doesn't exist anymore.

The `gen` folder is created during deployment and deletion, but the serviceaccount kubeconfig is only created during deployment of a component. Since it is sometimes rendered into helm charts, the deletion will fail if it doesn't exist.

This PR needs `sow` version `2.2.1` or higher to work.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Fixed a bug that caused deletion of a landscape to fail if the `gen` folder was missing. `sow` version `2.2.1` or higher is needed for this fix.
```
