### PR TITLE
change secret deletion behaviour of installation-handler

### DIFF
--- a/bin/installation-handler
+++ b/bin/installation-handler
@@ -68,11 +68,6 @@ prepare() {
       echo "Successfully restored secret '$sec_name' to '$dir'."
     done
   done
-
-  # all secrets have been restored to local disk, delete them (deletes all secrets with a "garden-setup.gardener.cloud/state" label, independent of its value)
-  if ! exec_retry 5 15 kubectl --kubeconfig "$kubeconfig" -n "$namespace" delete secrets -l "garden-setup.gardener.cloud/state"; then
-    fail "failed to delete secrets after restoring them to disk"
-  fi
   echo "### END PREPARE INSTALLATION ###"
 }
 
@@ -94,7 +89,12 @@ finalize() {
   if [[ "$backupLocation" == "null" ]] || [[ ! -d "$backupLocation" ]]; then
     backupLocation="$ROOT"
   fi  
-  
+
+  # delete all secrets with a "garden-setup.gardener.cloud/state" label, independent of their values
+  if ! exec_retry 5 15 kubectl --kubeconfig "$kubeconfig" -n "$namespace" delete secrets -l "garden-setup.gardener.cloud/state"; then
+    fail "failed to delete secrets after restoring them to disk"
+  fi
+
   # create timestamp
   local ts=$(timestamp)
   local failed_files=""


### PR DESCRIPTION
**What this PR does / why we need it**:
Before, the installation handler deleted the state secrets, then performed the issued `sow` command and then created the new state secrets. If the sow command failed, the state was not in the cluster anymore and depending on the environment, it was hard to restore it.

With this change, the old state secrets are deleted after the `sow` command, immediately before creating the new ones. If the command fails, there will still be state in the cluster, although it might be outdated (which doesn't matter for some cases, e.g. if the failed command was a deletion).
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The provided installation handler now deletes the state secrets immediately before updating them, after performing the `sow` command. 
```
