### PR TITLE
bugfixes

### DIFF
--- a/components/gardencontent/seeds/soils/action
+++ b/components/gardencontent/seeds/soils/action
@@ -40,7 +40,6 @@ cleanup()
       persistentvolumeclaim/elasticsearch-logging-elasticsearch-logging-0 \
       persistentvolumeclaim/fluentd-fluentd-es-0 \
       persistentvolumeclaim/prometheus-db-aggregate-prometheus-0 \
-      persistentvolumeclaim/prometheus-db-garden-prometheus-0 \
       daemonset.apps/fluent-bit \
       deployment.apps/etcd-druid \
       deployment.apps/dependency-watchdog-endpoint \

--- a/plugins/delete/plugin
+++ b/plugins/delete/plugin
@@ -28,7 +28,7 @@ prepare_delete() {
         seed)
             # abort if any shoot is still using the given seed
             verbose "Check if shoots are still running on seed '$1' ..."
-            if [[ $(kubectl get shoots --all-namespaces -o json | jq -r '[.items[].spec.seedName] | contains(["'$2'"])') == "true" ]]; then
+            if [[ $(kubectl get shoots --all-namespaces -o json | jq -r 'reduce (.items[].spec.seedName | . == "'$2'") as $b (false; . or $b)') == "true" ]]; then
                 fail "there are still shoots running on seed '$2'"
             fi
             ;;


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug that caused a PVC to be deleted during soil cleanup that actually belongs to the monitoring stack instead of the seed controlplane. Kubernets prevents the deletion of PVCs that are still in use, causing the landscape deletion to get stuck.
```
```improvement operator
Fixed a bug in the detection whether there are still shoots running on a seed that is to be deleted. The bug caused false positives for certain soil/seed name combinations, preventing the deletion of the landscape.
```
