### PR TITLE
upgrade dashboard and extensions

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -57,6 +57,9 @@ dashboard:
       ca: (( imports.cert-controller.export.ca.crt || ~~ ))
       redirectUri: (( settings.dashboard_url "/auth/callback" ))
       clientSecret: (( imports.identity.export.dashboardClientSecret ))
+      public:
+        clientId: kube-kubectl
+        clientSecret: (( imports.identity.export.kubectlClientSecret ))
     tlsSecretName: (( imports.cert.export.certificate.secret_name ))
     tls: ~
     kubeconfig: (( format( "((! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -43,6 +43,7 @@ dashboard:
   namespace: (( .landscape.namespace ))
   values:
     apiServerUrl: (( imports.kube_apiserver.export.apiserver_url ))
+    apiServerCa: (( imports.kube_apiserver.export.kube_apiserver_ca.cert ))
     sessionSecret: (( rand("[:alnum:]", 30) ))
     hosts:
       - (( imports.identity.export.dashboard_dns ))

--- a/components/identity/export.yaml
+++ b/components/identity/export.yaml
@@ -21,6 +21,7 @@ export:
   callback_url: (( .settings.callbackUrl ))
   dashboard_url: (( .settings.dashboardUrl ))
   dashboardClientSecret: (( .state.dashboardClientSecret.value ))
+  kubectlClientSecret: (( .state.kubectlClientSecret.value ))
   dashboard_dns: (( .settings.dashboard_dns ))
   identity_dns: (( .settings.identity_dns ))
   identity_url: (( "https://" identity_dns ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -51,7 +51,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.40.2"
+        "version": "1.41.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,11 +8,11 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.7.7"
+          "version": "v0.7.8"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.5.0"
+          "version": "v1.6.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.5.0"
+          "version": "v1.5.1"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade Gardener dashboard to `1.41.0`
```
```improvement operator
Upgrade Gardener extension networking-calico to `v1.6.0`
```
```improvement operator
Upgrade Gardener extension provider-openstack to `v1.5.1`
```
```improvement operator
Upgrade Gardener extension dns-external to `v0.7.8`. This adapts the version of the dns-controller-manager accordingly.
```
