### PR TITLE
add us-gov-west-1 region to aws profile

### DIFF
--- a/components/gardencontent/profiles/provider/aws/iaas.yaml
+++ b/components/gardencontent/profiles/provider/aws/iaas.yaml
@@ -512,3 +512,8 @@ regions:
     - name: us-west-2c
     - name: us-west-2d
     name: us-west-2
+  - zones:
+    - name: us-gov-west-1a
+    - name: us-gov-west-1b
+    - name: us-gov-west-1c
+    name: us-gov-west-1


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds us-gov-west-1 to the set of profiles for garden-setup. The AMIs already exist for several OS types but the region was missing in the profile.

Which issue(s) this PR fixes:
#203

Special notes for your reviewer:
nothing special. simple PR.

*Release Notes*:
``` improvement operator
Allow operators to deploy to us-gov-west-1 AWS region without specifying config in acre.yaml.
```