### PR TITLE
remove superfluous credential transformation in gardener/virtual component

### DIFF
--- a/components/gardencontent/seeds/shoots/deployment.yaml
+++ b/components/gardencontent/seeds/shoots/deployment.yaml
@@ -43,7 +43,7 @@ domain-secret:
           dns.gardener.cloud/provider: (( .landscape.dns.type ))
           dns.gardener.cloud/domain: (( "seed." .landscape.domain ))
       type: Opaque
-      data: (( imports.gardener.export.dns_credentials ))
+      data: (( sum[landscape.dns.credentials|{}|c,k,v|-> c {k=base64(v)}] ))
 
 shootconfig:
   <<: (( &template &temporary ))

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -20,7 +20,7 @@ env: (( &temporary ))
 
 settings:
   seedCandidateDeterminationStrategy: (( .landscape.gardener.seedCandidateDeterminationStrategy || "SameRegion" ))
-  dns_credentials: (( *.dns_credentials[.landscape.dns.type] ))
+  dns_credentials: (( sum[landscape.dns.credentials|{}|c,k,v|-> c {k=base64(v)}] ))
 
 spec:
   <<: (( &temporary ))
@@ -42,34 +42,6 @@ spec:
       - Signature
       - KeyEncipherment
     hosts: (( utilities.svcHosts(name, landscape.namespace) ))
-
-
-dns_credentials:
-  <<: (( &temporary ))
-  aws-route53:
-    <<: (( &template ))
-    AWS_ACCESS_KEY_ID: (( base64( landscape.dns.credentials.accessKeyID ) ))
-    AWS_SECRET_ACCESS_KEY: (( base64( landscape.dns.credentials.secretAccessKey ) ))
-    AWS_REGION: (( base64( landscape.dns.credentials.region ) || ~~ ))
-  google-clouddns:
-    <<: (( &template ))
-    serviceaccount.json: (( base64( landscape.dns.credentials.["serviceaccount.json"] ) ))
-  azure-dns:
-    <<: (( &template ))
-    AZURE_CLIENT_ID: (( base64( landscape.dns.credentials.clientID ) ))
-    AZURE_CLIENT_SECRET: (( base64( landscape.dns.credentials.clientSecret ) ))
-    AZURE_SUBSCRIPTION_ID: (( base64( landscape.dns.credentials.subscriptionID ) ))
-    AZURE_TENANT_ID: (( base64( landscape.dns.credentials.tenantID ) ))
-  openstack-designate:
-    <<: (( &template ))
-    OS_AUTH_URL: (( base64( landscape.dns.credentials.authURL ) ))
-    OS_REGION_NAME: (( base64( landscape.dns.credentials.region ) ))
-    OS_USERNAME: (( base64( landscape.dns.credentials.username ) ))
-    OS_PASSWORD: (( base64( landscape.dns.credentials.password ) ))
-    OS_DOMAIN_NAME: (( base64( landscape.dns.credentials.domainName ) ))
-    OS_USER_DOMAIN_NAME: (( base64( landscape.dns.credentials.userDomainName || "" ) ))
-    OS_PROJECT_NAME: (( base64( landscape.dns.credentials.tenantName ) ))
-
 
 state:
   <<: (( &state(merge none) ))
@@ -231,11 +203,11 @@ gardener:
               candidateDeterminationStrategy: (( .settings.seedCandidateDeterminationStrategy ))
         # kubeconfig: is only needed for the runtime chart and will be added in export step
       defaultDomains:
-        - credentials: (( *.dns_credentials.[provider] ))
+        - credentials: (( .settings.dns_credentials ))
           domain: (( "shoot." .landscape.domain ))
           provider: (( .landscape.dns.type ))
       internalDomain:
-        credentials: (( *.dns_credentials.[provider] ))
+        credentials: (( .settings.dns_credentials ))
         domain: (( "internal." .landscape.domain ))
         provider: (( .landscape.dns.type ))
       deployment:

--- a/components/gardener/virtual/export.yaml
+++ b/components/gardener/virtual/export.yaml
@@ -26,4 +26,3 @@ export:
         scheduler:
           <<: (( .gardener.values.global.scheduler ))
           kubeconfig: (( read( env.GENDIR "/kubectl_apply/sa_gardener-scheduler.kubeconfig", "text" ) ))
-  dns_credentials: (( .settings.dns_credentials ))


### PR DESCRIPTION
Remove superfluous mapping of dns credentials.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
