### PR TITLE
Upgrade terraform manifests to terraform 0.12

### DIFF
--- a/components/etcd/backupinfra/provider/abs/export.yaml
+++ b/components/etcd/backupinfra/provider/abs/export.yaml
@@ -1,3 +1,3 @@
-bucketname: (( data.terraform.modules.[0].outputs.bucketName.value ))
-azureStorageAccountName: (( data.terraform.modules.[0].outputs.storageAccountName.value ))
-azureStorageAccessKey: (( data.terraform.modules.[0].outputs.storageAccessKey.value ))
+bucketname: (( data.terraform.outputs.bucketName.value ))
+azureStorageAccountName: (( data.terraform.outputs.storageAccountName.value ))
+azureStorageAccessKey: (( data.terraform.outputs.storageAccessKey.value ))

--- a/components/etcd/backupinfra/provider/abs/main.tf
+++ b/components/etcd/backupinfra/provider/abs/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  client_id       = "${var.CLIENT_ID}"
-  client_secret   = "${var.CLIENT_SECRET}"
-  tenant_id       = "${var.TENANT_ID}"
-  subscription_id = "${var.SUBSCRIPTION_ID}"
-  version         = "=1.22.0"
+  client_id       = var.CLIENT_ID
+  client_secret   = var.CLIENT_SECRET
+  tenant_id       = var.TENANT_ID
+  subscription_id = var.SUBSCRIPTION_ID
+  version         = "=1.27.0"
 }
 
 //=====================================================================
@@ -11,14 +11,14 @@ provider "azurerm" {
 //=====================================================================
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.RESOURCE_GROUP}"
-  location = "${var.REGION}"
+  name     = var.RESOURCE_GROUP
+  location = var.REGION
 }
 
 resource "azurerm_storage_account" "storageAccount" {
-  name                     = "${var.STORAGE_ACCOUNT_NAME}"
-  location                 = "${var.REGION}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
+  name                     = var.STORAGE_ACCOUNT_NAME
+  location                 = var.REGION
+  resource_group_name      = azurerm_resource_group.rg.name
   account_kind             = "BlobStorage"
   access_tier              = "Hot"
   account_tier             = "Standard"
@@ -27,9 +27,9 @@ resource "azurerm_storage_account" "storageAccount" {
 }
 
 resource "azurerm_storage_container" "container" {
-  name                  = "${var.BUCKETNAME}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
-  storage_account_name  = "${azurerm_storage_account.storageAccount.name}"
+  name                  = var.BUCKETNAME
+  resource_group_name   = azurerm_resource_group.rg.name
+  storage_account_name  = azurerm_storage_account.storageAccount.name
   container_access_type = "private"
 }
 
@@ -38,14 +38,15 @@ resource "azurerm_storage_container" "container" {
 //=====================================================================
 
 output "bucketName" {
-  value = "${azurerm_storage_container.container.name}"
+  value = azurerm_storage_container.container.name
 }
 
 output "storageAccountName" {
-  value = "${azurerm_storage_account.storageAccount.name}"
+  value = azurerm_storage_account.storageAccount.name
 }
 
 output "storageAccessKey" {
   sensitive = true
-  value     = "${azurerm_storage_account.storageAccount.primary_access_key}"
+  value     = azurerm_storage_account.storageAccount.primary_access_key
 }
+

--- a/components/etcd/backupinfra/provider/abs/main.tf
+++ b/components/etcd/backupinfra/provider/abs/main.tf
@@ -3,7 +3,8 @@ provider "azurerm" {
   client_secret   = var.CLIENT_SECRET
   tenant_id       = var.TENANT_ID
   subscription_id = var.SUBSCRIPTION_ID
-  version         = "=1.27.0"
+  version         = "=2.8"
+  features          {}
 }
 
 //=====================================================================
@@ -23,12 +24,10 @@ resource "azurerm_storage_account" "storageAccount" {
   access_tier              = "Hot"
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  enable_blob_encryption   = true
 }
 
 resource "azurerm_storage_container" "container" {
   name                  = var.BUCKETNAME
-  resource_group_name   = azurerm_resource_group.rg.name
   storage_account_name  = azurerm_storage_account.storageAccount.name
   container_access_type = "private"
 }

--- a/components/etcd/backupinfra/provider/abs/variables.tf
+++ b/components/etcd/backupinfra/provider/abs/variables.tf
@@ -1,38 +1,39 @@
 variable "CLIENT_ID" {
   description = "Azure Client ID"
-  type        = "string"
+  type        = string
 }
 
 variable "CLIENT_SECRET" {
   description = "Azure Client Secret"
-  type        = "string"
+  type        = string
 }
 
 variable "TENANT_ID" {
   description = "Azure Tenant ID"
-  type        = "string"
+  type        = string
 }
 
 variable "SUBSCRIPTION_ID" {
   description = "Azure Subscription ID"
-  type        = "string"
+  type        = string
 }
 
 variable "REGION" {
   description = "Region of the ABS bucket"
-  type = "string"
+  type        = string
 }
 
 variable "BUCKETNAME" {
   description = "Name of the bucket"
-  type = "string"
+  type        = string
 }
 
 variable "RESOURCE_GROUP" {
   description = "Azure Resource Group"
-  type = "string"
+  type        = string
 }
 
 variable "STORAGE_ACCOUNT_NAME" {
   description = "Name of the storeage account"
 }
+

--- a/components/etcd/backupinfra/provider/abs/versions.tf
+++ b/components/etcd/backupinfra/provider/abs/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/components/etcd/backupinfra/provider/gcs/export.yaml
+++ b/components/etcd/backupinfra/provider/gcs/export.yaml
@@ -1,1 +1,1 @@
-bucketname: (( data.terraform.modules.[0].outputs.bucketName.value ))
+bucketname: (( data.terraform.outputs.bucketName.value ))

--- a/components/etcd/backupinfra/provider/gcs/main.tf
+++ b/components/etcd/backupinfra/provider/gcs/main.tf
@@ -16,6 +16,7 @@ provider "google" {
   credentials = var.SERVICEACCOUNT
   project     = var.PROJECT
   region      = var.REGION
+  version     = "=3.20"
 }
 
 //=====================================================================

--- a/components/etcd/backupinfra/provider/gcs/main.tf
+++ b/components/etcd/backupinfra/provider/gcs/main.tf
@@ -13,22 +13,20 @@
 // limitations under the License.
 
 provider "google" {
-  credentials = "${var.SERVICEACCOUNT}"
-  project     = "${var.PROJECT}"
-  region      = "${var.REGION}"
+  credentials = var.SERVICEACCOUNT
+  project     = var.PROJECT
+  region      = var.REGION
 }
-
 
 //=====================================================================
 //= GCS bucket
 //=====================================================================
 
 resource "google_storage_bucket" "bucket" {
-  name          = "${var.BUCKETNAME}"
-  location      = "${var.REGION}"
+  name          = var.BUCKETNAME
+  location      = var.REGION
   force_destroy = true
   storage_class = "COLDLINE"
-
 }
 
 //=====================================================================
@@ -36,5 +34,6 @@ resource "google_storage_bucket" "bucket" {
 //=====================================================================
 
 output "bucketName" {
-  value = "${google_storage_bucket.bucket.name}"
+  value = google_storage_bucket.bucket.name
 }
+

--- a/components/etcd/backupinfra/provider/gcs/variables.tf
+++ b/components/etcd/backupinfra/provider/gcs/variables.tf
@@ -14,20 +14,21 @@
 
 variable "SERVICEACCOUNT" {
   description = "ServiceAccount"
-  type        = "string"
+  type        = string
 }
 
 variable "REGION" {
   description = "Region of the GCS bucket"
-  type = "string"
+  type        = string
 }
 
 variable "BUCKETNAME" {
   description = "Name of the bucket"
-  type = "string"
+  type        = string
 }
 
 variable "PROJECT" {
   description = "GCS project"
-  type = "string"
+  type        = string
 }
+

--- a/components/etcd/backupinfra/provider/gcs/versions.tf
+++ b/components/etcd/backupinfra/provider/gcs/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/components/etcd/backupinfra/provider/s3/export.yaml
+++ b/components/etcd/backupinfra/provider/s3/export.yaml
@@ -1,1 +1,1 @@
-bucketname: (( data.terraform.modules.[0].outputs.bucketName.value ))
+bucketname: (( data.terraform.outputs.bucketName.value ))

--- a/components/etcd/backupinfra/provider/s3/main.tf
+++ b/components/etcd/backupinfra/provider/s3/main.tf
@@ -16,6 +16,7 @@ provider "aws" {
   access_key = var.ACCESS_KEY
   secret_key = var.SECRET_KEY
   region     = var.REGION
+  version    = "=2.60"
 }
 
 //=====================================================================

--- a/components/etcd/backupinfra/provider/s3/main.tf
+++ b/components/etcd/backupinfra/provider/s3/main.tf
@@ -13,22 +13,21 @@
 // limitations under the License.
 
 provider "aws" {
-  access_key  = "${var.ACCESS_KEY}"
-  secret_key  = "${var.SECRET_KEY}"
-  region      = "${var.REGION}"
+  access_key = var.ACCESS_KEY
+  secret_key = var.SECRET_KEY
+  region     = var.REGION
 }
-
 
 //=====================================================================
 //= S3 bucket
 //=====================================================================
 
 resource "aws_s3_bucket" "bucket" {
-  bucket_prefix = "${var.BUCKETNAME}"
-  region        = "${var.REGION}"
+  bucket_prefix = var.BUCKETNAME
+  region        = var.REGION
   force_destroy = true
-  tags          = {
-    Name        = "${var.LANDSCAPE}"
+  tags = {
+    Name = var.LANDSCAPE
   }
 }
 
@@ -37,5 +36,6 @@ resource "aws_s3_bucket" "bucket" {
 //=====================================================================
 
 output "bucketName" {
-  value = "${aws_s3_bucket.bucket.id}"
+  value = aws_s3_bucket.bucket.id
 }
+

--- a/components/etcd/backupinfra/provider/s3/variables.tf
+++ b/components/etcd/backupinfra/provider/s3/variables.tf
@@ -14,25 +14,26 @@
 
 variable "ACCESS_KEY" {
   description = "AWS Access Key"
-  type        = "string"
+  type        = string
 }
 
 variable "SECRET_KEY" {
   description = "AWS Secret Key"
-  type        = "string"
+  type        = string
 }
 
 variable "REGION" {
   description = "Region of the GCS bucket"
-  type = "string"
+  type        = string
 }
 
 variable "BUCKETNAME" {
   description = "Name of the bucket"
-  type = "string"
+  type        = string
 }
 
 variable "LANDSCAPE" {
   description = "Name of the Landscape (for tagging)"
-  type = "string"
+  type        = string
 }
+

--- a/components/etcd/backupinfra/provider/s3/versions.tf
+++ b/components/etcd/backupinfra/provider/s3/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/components/etcd/backupinfra/provider/swift/export.yaml
+++ b/components/etcd/backupinfra/provider/swift/export.yaml
@@ -1,1 +1,1 @@
-bucketname: (( data.terraform.modules.[0].outputs.bucketName.value ))
+bucketname: (( data.terraform.outputs.bucketName.value ))

--- a/components/etcd/backupinfra/provider/swift/main.tf
+++ b/components/etcd/backupinfra/provider/swift/main.tf
@@ -20,6 +20,7 @@ provider "openstack" {
   auth_url         = var.AUTH_URL
   domain_name      = var.DOMAIN_NAME
   user_domain_name = var.USER_DOMAIN_NAME
+  Version          = "=1.28"
 }
 
 //=====================================================================

--- a/components/etcd/backupinfra/provider/swift/main.tf
+++ b/components/etcd/backupinfra/provider/swift/main.tf
@@ -13,23 +13,22 @@
 // limitations under the License.
 
 provider "openstack" {
-  user_name        = "${var.USERNAME}"
-  password         = "${var.PASSWORD}"
-  tenant_name      = "${var.TENANT_NAME}"
-  region           = "${var.REGION}"
-  auth_url         = "${var.AUTH_URL}"
-  domain_name      = "${var.DOMAIN_NAME}"
-  user_domain_name = "${var.USER_DOMAIN_NAME}"
+  user_name        = var.USERNAME
+  password         = var.PASSWORD
+  tenant_name      = var.TENANT_NAME
+  region           = var.REGION
+  auth_url         = var.AUTH_URL
+  domain_name      = var.DOMAIN_NAME
+  user_domain_name = var.USER_DOMAIN_NAME
 }
-
 
 //=====================================================================
 //= GCS bucket
 //=====================================================================
 
 resource "openstack_objectstorage_container_v1" "bucket" {
-  name          = "${var.BUCKETNAME}"
-  region        = "${var.REGION}"
+  name          = var.BUCKETNAME
+  region        = var.REGION
   force_destroy = true
 }
 
@@ -38,5 +37,6 @@ resource "openstack_objectstorage_container_v1" "bucket" {
 //=====================================================================
 
 output "bucketName" {
-  value = "${openstack_objectstorage_container_v1.bucket.name}"
+  value = openstack_objectstorage_container_v1.bucket.name
 }
+

--- a/components/etcd/backupinfra/provider/swift/variables.tf
+++ b/components/etcd/backupinfra/provider/swift/variables.tf
@@ -14,41 +14,42 @@
 
 variable "USERNAME" {
   description = "Username"
-  type        = "string"
+  type        = string
 }
 
 variable "PASSWORD" {
   description = "Password"
-  type        = "string"
+  type        = string
 }
 
 variable "REGION" {
   description = "Region of the swift bucket"
-  type = "string"
+  type        = string
 }
 
 variable "BUCKETNAME" {
   description = "Name of the bucket"
-  type = "string"
+  type        = string
 }
 
 variable "TENANT_NAME" {
   description = "OpenStack Tenant"
-  type = "string"
+  type        = string
 }
 
 variable "AUTH_URL" {
   description = "OpenStack Auth URL"
-  type = "string"
+  type        = string
 }
 
 variable "DOMAIN_NAME" {
   description = "OpenStack Domain Name"
-  type = "string"
+  type        = string
 }
 
 variable "USER_DOMAIN_NAME" {
   description = "OpenStack User Domain Name"
-  type = "string"
-  default = ""
+  type        = string
+  default     = ""
 }
+

--- a/components/etcd/backupinfra/provider/swift/versions.tf
+++ b/components/etcd/backupinfra/provider/swift/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
⚠️ The terraform manifests have been upgraded to terraform `0.12`, therefore `sow` version `3.0.0` or higher is required. That version and following versions of sow won't work with earlier releases of garden-setup.
```
