### PR TITLE
expand openstack cloudprofile configuration options

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -313,6 +313,8 @@ validation:
                     - ["mapfield", "size"]
           - ["optionalfield", "dhcpDomain", "dnsdomain"]
           - ["optionalfield", "keystoneURL", "dnsdomain"]
+          - ["optionalfield", "useOctavia", ["type", "bool"]]
+          - ["optionalfield", "dnsServers", ["list", ["ip"]]]
           - - or
             - - mapfield
               - cloudprofile

--- a/components/gardencontent/profiles/provider/openstack/iaas.yaml
+++ b/components/gardencontent/profiles/provider/openstack/iaas.yaml
@@ -18,6 +18,8 @@ providerConfig:
   apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
   kind: CloudProfileConfig
   keystoneURL: (( values.config.keystoneURL || values.credentials.authURL ))
+  useOctavia: (( values.config.useOctavia || ~~ ))
+  dnsServers: (( values.config.dnsServers || ~~ ))
   constraints:
     floatingPools: (( values.config.floatingPools ))
     loadBalancerProviders: (( values.config.loadBalancerProviders ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -231,6 +231,9 @@ landscape:
         - name: my-floating-pool-network
       loadBalancerProviders:
         - name: haproxy
+      useOctavia: false # optional
+      dnsServers: # optional
+        - "8.8.8.8"
       extensionConfig:
         machineImages:
           - name: coreos


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The fields `useOctavia` and `dnsServers` in the OpenStack cloudprofile can now be configured in the acre.yaml.
```
