### PR TITLE
Upgrade Gardener extensions, metrics exporter, and kubernetes versions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -177,7 +177,7 @@ landscape:
       gardener-metrics-exporter:
         <<: (( merge ))
         repo: https://github.com/gardener/gardener-metrics-exporter.git
-        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.8.0" ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.9.0" ))
         image_tag: (( valid( tag ) ? tag :~~ ))
         image_repo: (( ~~ ))
   iaas: (( merge none // map[ select[stub()|e|-> ( ! defined( e.mode ) ) -or ( e.mode != "inactive" ) ] |idx,v|-> v { "mode" = v.mode || "seed" } ] ))

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -49,12 +49,8 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - version: 1.18.1
-      - version: 1.17.4
-      - version: 1.16.8
+      - version: 1.18.2
+      - version: 1.17.5
+      - version: 1.16.9
       - version: 1.15.11
-      - version: 1.14.10
-      - version: 1.13.12
-      - version: 1.12.10
-      - version: 1.11.10
   providerspec: (( *values.providerspec ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.4.0"
+          "version": "v1.6.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.6.2"
+          "version": "v1.7.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.6.1"
+          "version": "v1.7.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.6.0"
+          "version": "v1.7.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.5.1"
+          "version": "v1.6.0"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.5.2"
+          "version": "v1.6.0"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade gardener-metrics-exporter to `0.9.0`
```
```improvement operator
Upgrade Gardener extension networking-calico to `v1.7.0`
```
```improvement operator
Upgrade Gardener extension provider-openstack to `v1.6.0`
```
```improvement operator
Upgrade Gardener extension provider-azure to `v1.7.0`
```
```improvement operator
Upgrade Gardener extension provider-gcp to `v1.6.0`
```
```improvement operator
Upgrade Gardener extension provider-aws to `v1.7.0`
```
```improvement operator
Upgrade Gardener extension shoot-cert-service to `v1.6.0`
```
```noteworthy operator
The default kubernetes versions in the cloudprofile have been upgraded to `1.18.2`, `1.17.5`, `1.16.9`. All versions older than `1.15.11` have been removed.
```