### PR TITLE
add gardenlinux image to AWS and GCP, and make it the default

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -76,6 +76,13 @@ landscape:
           chart_path: charts/gardener-extension-os-ubuntu
           image_tag: (( valid( os-ubuntu.tag ) ? os-ubuntu.tag :~~ ))
           image_repo: (( ~~ ))
+        os-gardenlinux:
+          <<: (( merge ))
+          tag: (( valid( os-gardenlinux.branch ) -or valid( os-gardenlinux.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-gardenlinux.version ))
+          repo: (( .dependency_versions.versions.gardener.extensions.os-gardenlinux.repo ))
+          chart_path: charts/gardener-extension-os-gardenlinux
+          image_tag: (( valid( os-gardenlinux.tag ) ? os-gardenlinux.tag :~~ ))
+          image_repo: (( ~~ ))
         os-suse-jeos:
           <<: (( merge ))
           tag: (( valid( os-suse-jeos.branch ) -or valid( os-suse-jeos.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-suse-jeos.version ))

--- a/components/gardencontent/profiles/deployment.yaml
+++ b/components/gardencontent/profiles/deployment.yaml
@@ -26,3 +26,5 @@ kubectl: (( sum[profiles|[]|s,v|->s utilities.profile.create(v)] ))
 
 # contains a mapping from cloudprofile name to the first kubernetes version in the list of kubernetes versions for that cloudprofile
 k8sVersions: (( sum[kubectl.[*].manifests[0]|{}|s,e|-> s {e.metadata.name = e.spec.kubernetes.versions[0].version}] ))
+# contains a mapping from cloudprofile name to the first machineImage and its version in that cloudprofile
+machineImages: (( sum[kubectl.[*].manifests[0]|{}|s,e|-> s {e.metadata.name = {"name" = e.spec.machineImages[0].name, "version" = e.spec.machineImages[0].versions[0].version}}] ))

--- a/components/gardencontent/profiles/export.yaml
+++ b/components/gardencontent/profiles/export.yaml
@@ -14,8 +14,10 @@
 
 ---
 k8sVersions: (( &temporary ))
+machineImages: (( &temporary ))
 profiles: (( &temporary ))
 
 export:
   k8sVersions: (( .k8sVersions ))
+  machineImages: (( .machineImages ))
   profiles: (( .profiles ))

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -30,6 +30,7 @@ defaults:
     providerConfig: (( defaults.providerspec.providerConfig || ~~ ))
     kubernetes: (( defaults.providerspec.kubernetes || defaults.kubernetes ))
     machineImages:
+      - <<: (( defaults.providerspec.machineImages || ~ ))
       - name: coreos
         versions:
         - version: 2303.3.0
@@ -39,7 +40,6 @@ defaults:
       - name: suse-jeos
         versions:
         - version: 15.1.20200406
-      - <<: (( defaults.providerspec.machineImages || ~ ))
     machineTypes:
       - <<: (( defaults.providerspec.machineTypes || ~ ))
     volumeTypes:

--- a/components/gardencontent/profiles/provider/aws/iaas.yaml
+++ b/components/gardencontent/profiles/provider/aws/iaas.yaml
@@ -14,10 +14,51 @@
 
 <<: (( &template ))
 
+machineImages:
+  - name: gardenlinux
+    versions:
+    - version: 11.29.2
+
 providerConfig:
   apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
   kind: CloudProfileConfig
   machineImages:
+  - name: gardenlinux
+    versions:
+    - regions:
+      - ami: ami-000d2086310590420
+        name: ap-northeast-1
+      - ami: ami-09fc319647fed587d
+        name: ap-northeast-2
+      - ami: ami-06b2b34c865a727dd
+        name: ap-south-1
+      - ami: ami-07a41ec3e2a35e173
+        name: ap-southeast-1
+      - ami: ami-0bd57bff5b781998a
+        name: ap-southeast-2
+      - ami: ami-00b3fc33d5454c4b0
+        name: ca-central-1
+      - ami: ami-0bdeaa78ccefae729
+        name: eu-central-1
+      - ami: ami-036e62d2d876b5a96
+        name: eu-north-1
+      - ami: ami-06458801dbaec803b
+        name: eu-west-1
+      - ami: ami-01c9ef2569df6ed09
+        name: eu-west-2
+      - ami: ami-0fcb07bf03161dadb
+        name: eu-west-3
+      - ami: ami-04843d98ee8f8b53a
+        name: sa-east-1
+      - ami: ami-0f07b6a0455e0446d
+        name: us-east-1
+      - ami: ami-01caede62e2f0e624
+        name: us-east-2
+      - ami: ami-073bebf92f03bb216
+        name: us-west-1
+      - ami: ami-0a8bb5d3794424acc
+        name: us-west-2
+      version: 11.29.2
   - name: coreos
     versions:
     - regions:

--- a/components/gardencontent/profiles/provider/gcp/iaas.yaml
+++ b/components/gardencontent/profiles/provider/gcp/iaas.yaml
@@ -14,10 +14,19 @@
 
 <<: (( &template ))
 
+machineImages:
+  - name: gardenlinux
+    versions:
+    - version: 11.29.2
+
 providerConfig:
   apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
   kind: CloudProfileConfig
   machineImages:
+  - name: gardenlinux
+    versions:
+    - image: projects/sap-se-gcp-gardenlinux/global/images/garden-linux-gcp-29-2
+      version: 11.29.2
   - name: coreos
     versions:
     - image: projects/coreos-cloud/global/images/coreos-stable-2303-3-0-v20191203

--- a/components/gardencontent/seeds/manifests/shoot_manifest.yaml
+++ b/components/gardencontent/seeds/manifests/shoot_manifest.yaml
@@ -71,7 +71,7 @@ templates:
     machine:
       type: (( elem.machine.type || cvalues.iaas.defaultMachineType ))
       image:
-        name: (( elem.machine.image.name || cvalues.type == "openstack" ? cvalues.config.machineImages[0].name :"coreos" ))
+        name: (( elem.machine.image.name || cvalues.defaultMachineImage ))
         version: (( elem.machine.image.version || cvalues.type == "openstack" ? cvalues.config.machineImages[0].versions[0].version :~~ ))
     volume:
       <<: (( cvalues.type == "openstack" ? ~~ :~ ))

--- a/components/gardencontent/seeds/shoots/deployment.yaml
+++ b/components/gardencontent/seeds/shoots/deployment.yaml
@@ -56,6 +56,7 @@ shootconfig:
     iaas: (( read(__ctx.DIR "/../provider/" v.type "/shoot.yaml", "import") ))
     cloudprofile: (( v.cloudprofile || v.name ))
     k8sVersion: (( v.k8sVersion || imports.profiles.export.k8sVersions[cloudprofile] ))
+    defaultMachineImage: (( imports.profiles.export.machineImages[cloudprofile].name ))
     seed: (( v.seed ))
     secretbinding: (( ( "v" = { "type" = v.type, "name" = cloudprofile }, "settings" = { "project_name" = imports.project.export.project_name } ) *imports.project.export.secret_name_template ))
     config: (( v ))

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -33,6 +33,7 @@ deployment:
     - os-coreos
     - os-ubuntu
     - os-suse-jeos
+    - os-gardenlinux
     - dns-external
     - networking-calico
     - <<: (( sum[.infrastructures|[]|s,e|-> s [ "provider-" e ]] ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -104,6 +104,35 @@ extension_manifests:
         type: ubuntu
 
 ########################################
+  os-gardenlinux:
+########################################
+    <<: (( &template ))
+    apiVersion: core.gardener.cloud/v1beta1
+    kind: ControllerRegistration
+    metadata:
+      name: os-gardenlinux
+    spec:
+      deployment:
+        providerConfig:
+          chart: (( encoded_chart ))
+          values:
+            concurrentSyncs: 25
+            image:
+              repo: (( version.image_repo || ~~ ))
+              tag: (( version.image_tag || ~~ ))
+            resources:
+              limits:
+                cpu: 300m
+                memory: 512Mi
+              requests:
+                cpu: 20m
+                memory: 128Mi
+        type: helm
+      resources:
+      - kind: OperatingSystemConfig
+        type: gardenlinux
+
+########################################
   os-suse-jeos:
 ########################################
     <<: (( &template ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -26,6 +26,10 @@
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
           "version": "v1.5.0"
         },
+        "os-gardenlinux": {
+          "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
+          "version": "v0.1.0"
+        },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
           "version": "v1.7.0"

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -175,7 +175,7 @@ maxUnavailable: 0
 machine:
   type: <depends on iaas provider>
   image:
-    name: coreos # or first image from `machineImages` for openstack
+    name: <first image specified in the cloudprofile> # 'gardenlinux' by default
     version: <some coreos version>
 volume:
   type: <depends on iaas provider>


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `gardenlinux` OS is now available for AWS and GCP. It will be used by default for shooted seeds and it is the pre-selected option in the shoot creation dialog in the Gardener dashboard.
```
