### PR TITLE
Fix case sensitive issuerURL to issuerUrl in docs

### DIFF
--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -49,8 +49,8 @@ The `redirectURI` does not have to be provided, garden-setup will automatically 
 
 ## Configuration Options
 
-Apart from `users` and `connectors`, some other values can be configured in `landscape.iaas`:
+Apart from `users` and `connectors`, some other values can be configured in `landscape.identity`:
 
-The issuer URL can be set via `landscape.identity.issuerURL`. The default is `https://gardener.ing.<landscape.domain>/oidc`.
+The issuer URL can be set via `landscape.identity.issuerUrl`. The default is `https://gardener.ing.<landscape.domain>/oidc`.
 
 By setting `landscape.identity.dashboardClientSecret` or `landscape.identity.kubectlClientSecret`, the corresponding client secret(s) can be defined. By default, a random value is generated for the first deployment, which is then stored in the state so it doesn't change on redeployments.


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes a case sensitive key used in the docs. Moreover it also fixes a wrong key getting used in the docs.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
