### PR TITLE
Fixed health url for Dex in prometheus blackbox

### DIFF
--- a/components/monitoring/prometheus/manifests/scrape-configs/scrape-blackbox-dex.yaml
+++ b/components/monitoring/prometheus/manifests/scrape-configs/scrape-blackbox-dex.yaml
@@ -8,7 +8,7 @@ metrics_path: /probe
 scheme: http
 static_configs:
 - targets:
-  - (( .imports.identity.export.identity_url "/healthz" ))
+  - (( .imports.identity.export.issuer_url "/healthz" ))
   labels:
     purpose: availability
 relabel_configs:


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the healthz url for dex
**Which issue(s) this PR fixes**:
#231 
**Special notes for your reviewer**:
When the healthz url changes in the config, and grafana tries to fetch a dataset, it might fetch 2 datasets, one tied with the old url and the other with the new url. This will cause the health to not display for Dex. One way to "fix" this is to decrease the time range in grafana dashboard so that very old records with the incorrect healthz are not fetched.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed health URL for dex in prometheus blackbox config.
```
