### PR TITLE
upgrade kubernetes versions in cloudprofile

### DIFF
--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -49,8 +49,8 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - version: 1.18.2
-      - version: 1.17.5
-      - version: 1.16.9
-      - version: 1.15.11
+      - version: 1.18.3
+      - version: 1.17.6
+      - version: 1.16.10
+      - version: 1.15.12
   providerspec: (( *values.providerspec ))


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The cloudprofile default kubernetes versions have been bumped to `1.18.3`, `1.17.6`, `1.16.10`, and `1.15.12`.
```
