### PR TITLE
identity refactoring

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -55,7 +55,7 @@ dashboard:
     oidc:
       issuerUrl: (( imports.identity.export.issuer_url ))
       ca: (( imports.cert-controller.export.ca.crt || ~~ ))
-      redirectUri: (( settings.dashboard_url "/auth/callback" ))
+      redirectUri: (( imports.identity.export.callback_url ))
       clientSecret: (( imports.identity.export.dashboardClientSecret ))
       public:
         clientId: kube-kubectl
@@ -128,7 +128,7 @@ util:
 
 settings:
   serviceaccount_name: gardener-dashboard
-  dashboard_url: (( "https://" imports.identity.export.dashboard_dns ))
+  dashboard_url: (( .imports.identity.export.dashboard_url ))
 
 kubectl_sa:
   kubeconfig: (( .imports.kube_apiserver.export.kubeconfig ))

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -37,7 +37,7 @@ spec:
   <<: (( &temporary ))
 
   passwords:
-    input: (( landscape.identity.users || [] ))
+    input: (( landscape.identity.users ( landscape.identity.unprivilegedUsers || [] ) || [] ))
     value:
       <<: (( &template ))
       state: (( map[input|v|->{ "email"=v.email, "username"=v.username, "hash"=( v.hash || bcrypt(v.password) ) }] ))

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -43,10 +43,11 @@ spec:
       state: (( map[input|v|->{ "email"=v.email, "username"=v.username, "hash"=( v.hash || bcrypt(v.password) ) }] ))
 
 settings:
-  issuerUrl: (( .landscape.identity.issuerUrl || "https://" dashboard_dns "/oidc" ))
-  callbackUrl: (( issuerUrl "/callback" ))
+  issuerUrl: (( .landscape.identity.issuerUrl || "https://" identity_dns "/oidc" ))
+  callbackUrl: (( dashboardUrl "/auth/callback" ))
   dashboardUrl: (( "https://" dashboard_dns ))
-  identity_dns: (( "identity." .imports.ingress-controller.export.ingress_domain ))
+  identityUrl: (( "https://" identity_dns ))
+  identity_dns: (( ( .landscape.identity.useIdentityDomain || false ) ? "identity." .imports.ingress-controller.export.ingress_domain :dashboard_dns ))
   dashboard_dns: (( "gardener." .imports.ingress-controller.export.ingress_domain ))
 
 state:
@@ -72,7 +73,7 @@ identity:
     dashboardOrigins:
       - (( .settings.dashboardUrl ))
     hosts:
-      - (( .settings.dashboard_dns ))
+      - (( .settings.identity_dns ))
     issuerUrl: (( .settings.issuerUrl ))
     connectors: (( injector.injectall(.landscape.identity.connectors || []) ))
     staticPasswords: (( state.staticPasswords.value ))

--- a/components/identity/export.yaml
+++ b/components/identity/export.yaml
@@ -24,4 +24,4 @@ export:
   kubectlClientSecret: (( .state.kubectlClientSecret.value ))
   dashboard_dns: (( .settings.dashboard_dns ))
   identity_dns: (( .settings.identity_dns ))
-  identity_url: (( "https://" identity_dns ))
+  identity_url: (( .settings.identityUrl ))

--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -54,3 +54,5 @@ Apart from `users` and `connectors`, some other values can be configured in `lan
 The issuer URL can be set via `landscape.identity.issuerUrl`. The default is `https://gardener.ing.<landscape.domain>/oidc`.
 
 By setting `landscape.identity.dashboardClientSecret` or `landscape.identity.kubectlClientSecret`, the corresponding client secret(s) can be defined. By default, a random value is generated for the first deployment, which is then stored in the state so it doesn't change on redeployments.
+
+It is possible to create additional users with static passwords but without privileges by providing a list of users in `landscape.identity.unprivilegedUsers`. The syntax is the same as for `landscape.identity.users`. There has to be at least one entry in `lansdcape.identity.users` for this list to be evaluated.

--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -35,7 +35,7 @@ In `landscape.identity.users`, a list of hard-coded users can be specified. They
         config:
           clientID: $GITHUB_CLIENT_ID
           clientSecret: $GITHUB_CLIENT_SECRET
-          # redirectURI: http://example.com/oidc/callback
+          # redirectURI: http://gardener.ing.<landscape.domain>/auth/callback
           orgs:
           - name: my-gardener-users
           teamNameField: slug
@@ -44,14 +44,14 @@ In addition to providing a list of hard-coded users, it is also possible to conn
 
 For a list of possible connectors and how to configure them, please check the documentation at https://github.com/dexidp/dex/tree/master/Documentation/connectors.
 
-The `redirectURI` does not have to be provided, garden-setup will automatically inject it into each connector's config if it is not there.
+The `redirectURI` does not have to be provided, garden-setup will automatically inject a default - see example above - into each connector's config if it is not there.
 
 
 ## Configuration Options
 
 Apart from `users` and `connectors`, some other values can be configured in `landscape.identity`:
 
-The issuer URL can be set via `landscape.identity.issuerUrl`. The default is `https://gardener.ing.<landscape.domain>/oidc`.
+The issuer URL can be set via `landscape.identity.issuerUrl`. The default is `https://gardener.ing.<landscape.domain>/oidc`. By setting `landscape.identity.useIdentityDomain` to `true`, Gardener dashboard and dex will use two different domains with the issuer URL defaulting to `https://identity.ing.<landscape.domain>/oidc` in this case.
 
 By setting `landscape.identity.dashboardClientSecret` or `landscape.identity.kubectlClientSecret`, the corresponding client secret(s) can be defined. By default, a random value is generated for the first deployment, which is then stored in the state so it doesn't change on redeployments.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors some domains used by the identity component and enables two new functionalities:
 - separating dex from the Gardener dashboard by using `landscape.identity.useIdentityDomain`
- creating dashboard users that don't have any privileges

**Which issue(s) this PR fixes**:
Fixes #229 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It's now possible to create static users without any privileges for the dashboard. See the [extended identity documentation](docs/extended/identity.md) for details.
```
```noteworthy operator
By setting `landscape.identity.useIdentityDomain` to `true`, identity can now be configured to use a separate domain than the Gardener dashboard. See the [extended identity documentation](docs/extended/identity.md) for details.
```
```action operator
During the refactoring of the identity component, the default `redirectURI` that is injected into each connector has changed from `https://gardener.ing.<landscape.domain>/oidc/callback` to `https://gardener.ing.<landscape.domain>/auth/callback`. You might need to adapt either your acre.yaml file or your connector.
```
