### PR TITLE
add option to overwrite gardenlet image vector

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -390,6 +390,35 @@ validation:
       - - optionalfield
         - credentials
         - (( types.iaas[values.type].credentials ))
+      - - optionalfield
+        - imageVectorOverwrite
+        - - mapfield
+          - images
+          - - list
+            - - and
+              - ["mapfield", "name"]
+              - ["mapfield", "sourceRepository"]
+              - ["mapfield", "repository"]
+              - ["optionalfield", "tag"]
+              - ["optionalfield", "version"]
+      - - optionalfield
+        - componentImageVectorOverwrite
+        - - mapfield
+          - components
+          - - list
+            - - and
+              - ["mapfield", "name"]
+              - - mapfield
+                - imageVectorOverwrite
+                - - mapfield
+                  - images
+                  - - list
+                    - - and
+                      - ["mapfield", "name"]
+                      - ["mapfield", "sourceRepository"]
+                      - ["mapfield", "repository"]
+                      - ["optionalfield", "tag"]
+                      - ["optionalfield", "version"]
       - <<: (( types.iaas[values.type].config ))
     initial_seed:
       - <<: (( &template ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -106,6 +106,8 @@ gardenletSpec:
       additionalVolumeMounts: []
       env: []
       vpa: false
+      imageVectorOverwrite: (( asyaml( configValues.imageVectorOverwrites.imageVectorOverwrite ) || ~~ ))
+      componentImageVectorOverwrites: (( asyaml( configValues.imageVectorOverwrites.componentImageVectorOverwrite ) || ~~ ))
       config:
         gardenClientConnection:
           acceptContentTypes: application/json

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -48,6 +48,9 @@ providerconfig:
   config: (( v ))
   isBaseCluster: false
   bootstrapToken: (( bootstrapTokens[v.name] ))
+  imageVectorOverwrites:
+    imageVectorOverwrite: (( v.imageVectorOverwrite || ~~ ))
+    componentImageVectorOverwrite: (( valid( v.componentImageVectorOverwrite ) ? { "components" = sum[v.componentImageVectorOverwrite.components|[]|cs,celem|-> s { "name" = celem.name, "imageVectorOverwrite" = asyaml( celem.imageVectorOverwrite ) }] } :~~ ))
   kubeconfigs:
     virtual: (( .imports.kube_apiserver.export.kubeconfig ))
     seed: (( .imports.shoots.export.shoots[v.name].kubeconfig ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -59,6 +59,9 @@ providerconfig:
   config: (( v ))
   isBaseCluster: (( ! valid( v.cluster.kubeconfig ) ))
   bootstrapToken: (( bootstrapTokens[v.name] ))
+  imageVectorOverwrites:
+    imageVectorOverwrite: (( v.imageVectorOverwrite || ~~ ))
+    componentImageVectorOverwrite: (( valid( v.componentImageVectorOverwrite ) ? { "components" = sum[v.componentImageVectorOverwrite.components|[]|cs,celem|-> s { "name" = celem.name, "imageVectorOverwrite" = asyaml( celem.imageVectorOverwrite ) }] } :~~ ))
   kubeconfigs:
     virtual: (( .imports.kube_apiserver.export.kubeconfig ))
     seed: (( v.cluster.kubeconfig || read( env.ROOTDIR "/" landscape.clusters.[0].kubeconfig, "yaml" ) ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -210,6 +210,38 @@ This would configure two worker groups, the first one completely with default va
 Note that if you don't overwrite the name, the first worker group will be named `cpu-worker` and each following worker group will be named `worker`, followed by its index. In the above example, the second worker group would have been named `worker1`, if the name wasn't overwritten.
 
 
+## Image Vector Overwrites
+
+The gardenlet takes an optional image vector overwrite, in case the default image registry is not reachable from the seed cluster (or shouldn't be used for some other reason). The syntax for overwriting the image vectors in the acre.yaml file is as shown below.
+
+```yaml
+iaas:
+  - name: (( type ))
+    ...
+    imageVectorOverwrite:                        # optional, overwrites image vector of gardenlet
+      images:
+        - name: pause-container
+          sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+          repository: my-custom-image-registry/pause-amd64
+          tag: "3.0"
+          version: 1.11.x
+    componentImageVectorOverwrite:               # optional, overwrites component image vector of gardenlet
+      components:
+        - name: etcd-druid
+          imageVectorOverwrite:
+            images:
+              - name: pause-container
+                sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+                repository: my-custom-image-registry/pause-amd64
+                tag: "3.0"
+                version: 1.11.x
+
+```
+
+For further information regarding the image vector overwrites, have a look at the documentation [here](https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md).
+Please note that the component image vector overwrites should be specified as YAML objects and not strings as shown in the aforementioned documentation. The conversion into strings is handled automatically by garden-setup.
+
+
 ## Overwriting Cloudprofiles
 
 By adding a `profile` node in a iaas entry, it is possible to overwrite parts of the cloudprofile. If the node is present, everything under it will be merged into the `spec` node of the cloudprofile. In this context, 'merged' means that every node that is directly under `spec` will be overwritten by what you specify here. You can add nodes that are not part of the default cloudprofile this way. Nodes on these levels that are not given here will use their defaults. A more fine-grained merge of values is not possible - the example above will not add `1.13.0` to the possible kubernetes versions in this cloudprofile, but instead set it to be the only available option.


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #241 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It's now possible to overwrite the gardenlet's image vector. Please see the [docs](docs/extended/iaas.md#image-vector-overwrite) for further information.
```
