### PR TITLE
Upgrade dashboard and extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -148,7 +148,7 @@ landscape:
       repo: https://github.com/gardener/terminal-controller-manager.git
       image_tag: (( valid( tag ) ? tag :~~ ))
       image_repo: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
-      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.9.0" ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.10.0" ))
     dns-controller:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -55,7 +55,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.42.0"
+        "version": "1.43.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.8.4"
+          "version": "v1.10.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.6.5"
+          "version": "v1.7.0"
         }
       }
     },


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Upgrade Gardener dashboard to `1.43.0`
```
```action operator
There are backwards incompatible changes in the dashboard's `frontendConfig` configuration. See the [release notes](https://github.com/gardener/dashboard/releases/tag/1.43.0) for details. If you don't explicitly configure `landscape.dashboard.frontendConfig` in your acre.yaml, there shouldn't be any changes required.
```
```improvement operator
Upgrade Gardener extension shoot-cert-service to `v1.7.0`
```
```improvement operator
Upgrade Gardener extension provider-azure to `v1.10.0`
```
```improvement operator
Upgrade terminal-controller-manager to `v0.10.0`
```

