### PR TITLE
Upgrade dashboard, extensions, and kubernetes versions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -148,7 +148,7 @@ landscape:
       repo: https://github.com/gardener/terminal-controller-manager.git
       image_tag: (( valid( tag ) ? tag :~~ ))
       image_repo: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
-      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.10.0" ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.11.0" ))
     dns-controller:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -49,8 +49,8 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - version: 1.18.3
-      - version: 1.17.6
+      - version: 1.18.4
+      - version: 1.17.7
       - version: 1.16.10
       - version: 1.15.12
   providerspec: (( *values.providerspec ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.10.0"
+          "version": "v1.10.1"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -55,7 +55,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.43.0"
+        "version": "1.43.1"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.7.0"
+          "version": "v1.7.1"
         }
       }
     },


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Upgrade Gardener dashboard to `1.43.1`
```
```improvement operator
Upgrade terminal-controller-manager to `v0.11.10`
```
```improvement operator
Upgrade Gardener extension shoot-cert-service to `v1.7.1`
```
```improvement operator
Upgrade Gardener extension provider-azure to `v1.10.1`
```
```improvement operator
Update default cloudprofile kubernetes versions to `1.18.4` and `1.17.7.`, respectively.
```