### PR TITLE
remove unsupported argument Version

### DIFF
--- a/components/etcd/backupinfra/provider/swift/main.tf
+++ b/components/etcd/backupinfra/provider/swift/main.tf
@@ -20,7 +20,6 @@ provider "openstack" {
   auth_url         = var.AUTH_URL
   domain_name      = var.DOMAIN_NAME
   user_domain_name = var.USER_DOMAIN_NAME
-  Version          = "=1.28"
 }
 
 //=====================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:
In the deployment with garden-setup on OpenStack Iaas an terraform error occurs:

```
Error: Unsupported argument

  on ../../../../crop/components/etcd/backupinfra/provider/swift/main.tf line 23, in provider "openstack":
  23:   Version          = "=1.28"

An argument named "Version" is not expected here.
```

After remove this line all works like expected.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Tested with sow in version 3.1.0 

**Release note**:
NONE

