### PR TITLE
Update extensions and other components

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -180,7 +180,7 @@ landscape:
         image_tag: v0.0.1
       grafana:
         image_repo: grafana/grafana
-        image_tag: "6.3.2"
+        image_tag: "7.0.3"
       gardener-metrics-exporter:
         <<: (( merge ))
         repo: https://github.com/gardener/gardener-metrics-exporter.git

--- a/acre.yaml
+++ b/acre.yaml
@@ -184,7 +184,7 @@ landscape:
       gardener-metrics-exporter:
         <<: (( merge ))
         repo: https://github.com/gardener/gardener-metrics-exporter.git
-        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.10.0" ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.11.0" ))
         image_tag: (( valid( tag ) ? tag :~~ ))
         image_repo: (( ~~ ))
   iaas: (( merge none // map[ select[stub()|e|-> ( ! defined( e.mode ) ) -or ( e.mode != "inactive" ) ] |idx,v|-> v { "mode" = v.mode || "seed" } ] ))

--- a/components/cert-manager/controller/action
+++ b/components/cert-manager/controller/action
@@ -29,14 +29,23 @@ webhookready()
       return
     fi
 
-    debug "webhook replicas: $(kubectl -n "$namespace" get deployment cert-manager-webhook -o jsonpath='{.status.readyReplicas}')"
-    while true; do
-      replicas=$(kubectl -n "$namespace" get deployment cert-manager-webhook -o jsonpath='{.status.readyReplicas}')
-      if [[ ${replicas:-0} -gt 0 ]]; then
-        break
-      fi
-      echo "waiting for cert-manager webhook to be running"
-      sleep 10
-    done
+    local starttime
+    local endtime
+    local timeout=600
+    starttime=$(date +%s)
+    endtime=$(( starttime + timeout ))
+
+    if [[ -z "$DRYRUN" ]]; then
+      debug "webhook replicas: $(kubectl -n "$namespace" get deployment cert-manager-webhook -o jsonpath='{.status.readyReplicas}')"
+      while [[ $(date +%s) -le $endtime ]]; do
+        replicas=$(kubectl -n "$namespace" get deployment cert-manager-webhook -o jsonpath='{.status.readyReplicas}')
+        if [[ ${replicas:-0} -gt 0 ]]; then
+          return
+        fi
+        echo "waiting for cert-manager webhook to be running"
+        sleep 10
+      done
+      fail "cert-manager-webhook did not become ready within $timeout seconds"
+    fi
   fi
 }

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -49,8 +49,8 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - version: 1.18.4
-      - version: 1.17.7
-      - version: 1.16.10
+      - version: 1.18.5
+      - version: 1.17.8
+      - version: 1.16.12
       - version: 1.15.12
   providerspec: (( *values.providerspec ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",
-          "version": "v1.4.0"
+          "version": "v1.5.0"
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-jeos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.7.2"
+          "version": "v1.8.2"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.5.0"
+          "version": "v1.6.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.8.0"
+          "version": "v1.8.1"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -55,7 +55,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.43.1"
+        "version": "1.43.2"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -55,7 +55,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.43.2"
+        "version": "1.43.3"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade Gardener extension os-ubuntu to `v1.6.0`
```
```improvement operator
Upgrade Gardener extension networking-calico to `v1.8.1`
```
```improvement operator
Upgrade Gardener extension provider-gcp to `v1.8.2`
```
```improvement operator
Upgrade Gardener dashboard to `1.43.3`
```
```improvement operator
Upgrade gardener-metrics-exporter to `0.11.0`
```
```improvement operator
Upgrade Grafana for Gardener monitoring to `7.0.3`
```
```improvement operator
Upgrade default cloudprofile kubernetes versions to `1.18.5`, `1.17.8`, and `1.16.12`, respectively.
```
```improvement operator
Upgrade Gardener extension os-coreos to `v1.5.0`
```
