### PR TITLE
reactivate seed logging

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -171,7 +171,7 @@ gardenletSpec:
         logLevel: info
         kubernetesLogLevel: 0
         featureGates:
-          Logging: false # TODO temporary workaround, revert once fixed in Gardener
+          Logging: true
         seedConfig:
           metadata:
             name: (( configValues.name ))


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the workaround introduced with #271 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The temporary workaround from release `2.1.0` (deactivation of seed logging) has been removed again.
```
