### PR TITLE
Upgrade ingress-controller

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -137,6 +137,18 @@ landscape:
       repo: (( .dependency_versions.versions.dashboard.core.repo ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.dashboard.core.version ))
       image_tag: (( valid( tag ) ? tag :~~ ))
+    ingress-controller:
+      <<: (( merge ))
+      repo: https://github.com/kubernetes/ingress-nginx.git
+      image_tag: (( valid( tag ) ? tag :~~ ))
+      image_repo: eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.34.1" ))
+    nginx-ingress-k8s-backend:
+      <<: (( merge ))
+      repo: https://github.com/gardener/ingress-default-backend.git
+      image_tag: (( valid( tag ) ? tag :~~ ))
+      image_repo: eu.gcr.io/gardener-project/gardener/ingress-default-backend
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"0.8.0" ))
     identity:
       <<: (( merge ))
       repo: (( .dependency_versions.versions.dashboard.identity.repo ))

--- a/components/ingress-controller/chart/templates/00-ingress-controller.yaml
+++ b/components/ingress-controller/chart/templates/00-ingress-controller.yaml
@@ -50,6 +50,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -169,7 +170,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: {{ .Values.name }}
-          image: quay.io/kubernetes-ingress-controller/{{ .Values.name }}:0.20.0
+          image: {{ index .Values.images "nginx-ingress" }}
           imagePullPolicy: "IfNotPresent"
           args:
           - /{{ .Values.name }}
@@ -187,8 +188,8 @@ spec:
                 - ALL
                 add:
                 - NET_BIND_SERVICE
-            # www-data -> 33
-            runAsUser: 33
+            # www-data -> 101
+            runAsUser: 101
           env:
           - name: POD_NAME
             valueFrom:
@@ -302,7 +303,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: nginx-ingress-k8s-backend
-          image: eu.gcr.io/gardener-project/gardener/ingress-default-backend:0.7.0
+          image: {{ index .Values.images "ingress-k8s-backend" }}
           imagePullPolicy: "IfNotPresent"
           args:
           livenessProbe:

--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -37,3 +37,6 @@ ingresscontroller:
     name: (( .ingresscontroller.name ))
     dns: (( "*." .settings.ingress_domain ))
     dnsclass: (( imports.dns-controller.export.dns-class ))
+    images:
+        nginx-ingress: (( .landscape.versions.ingress-controller.image_repo ":" .landscape.versions.ingress-controller.image_tag ))
+        ingress-k8s-backend: (( .landscape.versions.nginx-ingress-k8s-backend.image_repo ":" .landscape.versions.nginx-ingress-k8s-backend.image_tag ))


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade ingress-controller to v0.34.1
Upgrade ingress-k8s-backend to v0.8.0

Change the following settings in the template for the new nginx-ingress version:
- set the runAsUser to 101
- add in the ClusterRole for the "ingresses" resource a second apiGroup "networking.k8s.io"

Move image_repo and image_tag to the versions section in the acre file for future upgrades.

**Which issue(s) this PR fixes**:
Update nginx ingress-controller #278

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade ingress-controller to v0.34.1
```
```improvement operator
Upgrade ingress-k8s-backend to v0.8.0
```
```improvement operator
Ingress images are now configurable in acre file
```
