### PR TITLE
add gardenlet-featureGates setting to acre.yaml

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -403,6 +403,15 @@ validation:
         - credentials
         - (( types.iaas[values.type].credentials ))
       - - optionalfield
+        - featureGates
+        - - and
+          - ["optionalfield", "Logging", ["type", "bool"]]
+          - ["optionalfield", "HVPA", ["type", "bool"]]
+          - ["optionalfield", "HVPAForShootedSeed", ["type", "bool"]]
+          - ["optionalfield", "ManagedIstio", ["type", "bool"]]
+          - ["optionalfield", "APIServerSNI", ["type", "bool"]]
+          - ["optionalfield", "KonnectivityTunnel", ["type", "bool"]]
+      - - optionalfield
         - imageVectorOverwrite
         - - mapfield
           - images

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -170,8 +170,9 @@ gardenletSpec:
           resourceLock: configmaps
         logLevel: info
         kubernetesLogLevel: 0
-        featureGates:
-          Logging: true
+        featureGates: 
+          <<: (( configValues.config.featureGates || {} ))
+          Logging: (( configValues.config.featureGates.Logging || true ))
         seedConfig:
           metadata:
             name: (( configValues.name ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -6,6 +6,8 @@ iaas:
     type: <gcp|aws|azure|openstack>              # iaas provider
     mode: <seed|soil>                            # optional, defaults to 'seed'
     cloudprofile: <name of cloudprofile>         # optional, will deploy its own cloudprofile if not specified
+    featureGates:                                # optional, set featureGates for the gardenlet. Logging is enable by default
+      Logging: true
     shootDefaultNetworks:                        # optional, overwrites defaults of .spec.networks.shootDefaults in the seed manifest
       pods: 100.96.0.0/11
       services: 100.64.0.0/13
@@ -71,6 +73,12 @@ If `mode` is set to `inactive`, the complete entry will be removed before the se
 
 By default - that means there is no `cloudprofile` field - each seed will be deployed with its own cloudprofile. However, you might want to have additional seeds (e.g. to support different regions) without having additional cloudprofiles. If the entry has mode `seed` or `soil` and has a `cloudprofile` node, it will not deploy a cloudprofile and instead use the one with the given name.
 Cloudprofiles are created first, before any seed. Thus, entries of `landscape.iaas` (as well as nested entries for shooted seeds, see below) can reference cloudprofiles defined by any other entry, independent of the position of either entry.
+
+
+## The 'featureGates' Field
+
+The `featureGates` field enable/disable featureGates for the gardenlet. By default - that means there is no `featureGates` field or no value for `featureGates.Logging` - the `Logging` featureGate will be enabled. To diasble the `Logging` featureGate you have to set the `featureGates.Logging` to `false`.
+A list of available featureGates you can find in the gardener documentation - [Feature Gates in Gardener](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)
 
 
 ## Shooted Seeds


### PR DESCRIPTION
**What this PR does / why we need it**:

Make gardenlet featureGates configurable in acre file. 
Logging featureGate is enabled by default (as before).

Thanks @Diaphteiros for your help with the default settings for the Logging featureGate.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gardenlet featureGates are now configurable in acre file
```
