### PR TITLE
Update extension/dashboard/terminal-controller-manager

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -160,7 +160,7 @@ landscape:
       repo: https://github.com/gardener/terminal-controller-manager.git
       image_tag: (( valid( tag ) ? tag :~~ ))
       image_repo: eu.gcr.io/gardener-project/gardener/terminal-controller-manager
-      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.11.0" ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :"v0.13.0" ))
     dns-controller:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.9.1"
+          "version": "v1.10.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -55,7 +55,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.45.0"
+        "version": "1.45.1"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade Gardener extension networking-calico to `v1.10.0`
```
```improvement operator
Upgrade Gardener dashboard to `1.45.1`
```
```improvement operator
Upgrade terminal-controller-manager to `v0.13.0`
```