### PR TITLE
added VPA as requirement to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Gardener uses Kubernetes to manage Kubernetes clusters. This documentation descr
   * [Viewing kubeconfig (GKE)](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#viewing_kubeconfig)
   * [Create a kubeconfig for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html)
   * [Use Azure role-based access controls to define access to the Kubernetes configuration file in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/control-kubeconfig-access)
+* You need to have the [Vertical Pod Autoscaler (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) installed. 
 
 ## Procedure
 


### PR DESCRIPTION
in case people see the following error they do not have the VPA and its respective crds installed. 

``` 
error: unable to recognize "/mounted/Users/Name/gardener-setup/landscape/gen/dns-controller/kubectl_apply/manifests/0-0-VerticalPodAutoscaler.kube-system.garden-setup-dns-controller-manager-vpa.yaml": no matches for kind "VerticalPodAutoscaler" in version "autoscaling.k8s.io/v1beta2"
```

after installing VPA the error disappears. 

**What this PR does / why we need it**:
see above 
