### PR TITLE
Fix callback url

### DIFF
--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -28,7 +28,7 @@ identity_version: (( &temporary ( .landscape.versions.identity ) ))
 
 injector:
   <<: (( &temporary ))
-  injectall: (( |list|->map[list|c|->merge(c, _.stub)] ))
+  injectall: (( |list|->map[list|c|-> valid( c.config.redirectURI ) ? c :merge(c, _.stub)] ))
   stub:
     config:
       redirectURI: (( &inject(settings.callbackUrl) ))

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -44,7 +44,7 @@ spec:
 
 settings:
   issuerUrl: (( .landscape.identity.issuerUrl || "https://" identity_dns "/oidc" ))
-  callbackUrl: (( dashboardUrl "/auth/callback" ))
+  callbackUrl: (( dashboardUrl "/oidc/callback" ))
   dashboardUrl: (( "https://" dashboard_dns ))
   identityUrl: (( "https://" identity_dns ))
   identity_dns: (( ( .landscape.identity.useIdentityDomain || false ) ? "identity." .imports.ingress-controller.export.ingress_domain :dashboard_dns ))

--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -35,7 +35,7 @@ In `landscape.identity.users`, a list of hard-coded users can be specified. They
         config:
           clientID: $GITHUB_CLIENT_ID
           clientSecret: $GITHUB_CLIENT_SECRET
-          # redirectURI: http://gardener.ing.<landscape.domain>/auth/callback
+          # redirectURI: https://gardener.ing.<landscape.domain>/oidc/callback
           orgs:
           - name: my-gardener-users
           teamNameField: slug


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #291 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed which caused the wrong callback url to be injected into dex connectors specified under `landscape.identity.connectors` in a way that made it impossible to overwrite it with a custom callback url.
```
