### PR TITLE
Add shootDomainPrefix to acre

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -595,6 +595,7 @@ validation:
     seedCandidateDeterminationStrategy:  (( validate( landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]] ) ))
     network-policies: (( defined( landscape.gardener.network-policies ) ? validate( landscape.gardener.network-policies, ["optionalfield", "active", ["type", "bool"]] ) :~~ ))
     extensions: (( defined( landscape.gardener.extensions ) ? validate( keys( landscape.gardener.extensions ), ["list", ["valueset", keys( landscape.versions.gardener.extensions )]] ) :~~ ))
+    shootDomainPrefix: (( defined( landscape.gardener.shootDomainPrefix ) ? validate( landscape.gardener, ["optionalfield", "shootDomainPrefix", "dnslabel"] ) :~~ ))
   ##### landscape.dashboard
   dashboard: (( defined( landscape.dashboard ) ? validate( landscape.dashboard, validation.dashboard_validator, validation.dashboard_no_seed_strategy_validator, [validation.dashboard_terminals_validator, landscape.cert-manager] ) :~~ ))
   ##### landscape.certmanager

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -205,7 +205,7 @@ gardener:
         # kubeconfig: is only needed for the runtime chart and will be added in export step
       defaultDomains:
         - credentials: (( .settings.dns_credentials ))
-          domain: (( "shoot." .landscape.domain ))
+          domain: (( defined( .landscape.gardener.shootDomainPrefix ) ? .landscape.gardener.shootDomainPrefix "." .landscape.domain :"shoot." .landscape.domain ))
           provider: (( .landscape.dns.type ))
       internalDomain:
         credentials: (( .settings.dns_credentials ))

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -54,3 +54,6 @@ Example to set the `imageVectorOverwrite` (see [values.yaml](https://github.com/
               repository: some-other-registry/calico/typha
             ...
 ```
+
+#### Change default shoot prefix domain
+Per default all shoot api server domains are something like '<clustername>.<project>.shoot.<basedomain>'. If you want to change the 'shoot' term you can use `landscape.gardener.shootDomainPrefix` and set a value you like.  


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the possibility to configure the shoot prefix in shoot URLs.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Add possibility to configure the shoot prefix in shoot URLs.
```
