### PR TITLE
fix validation for landscape.gardener.seedCandidateDeterminationStrategy

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -592,7 +592,7 @@ validation:
     credentials: (( validate( landscape.dns, ["mapfield", "credentials", types.dns[landscape.dns.type].credentials] ) ))
   ##### landscape.gardener
   gardener:
-    seedCandidateDeterminationStrategy:  (( validate( landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]] ) ))
+    seedCandidateDeterminationStrategy: (( defined( landscape.gardener.seedCandidateDeterminationStrategy ) ? validate( landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]] ) :~~ ))    
     network-policies: (( defined( landscape.gardener.network-policies ) ? validate( landscape.gardener.network-policies, ["optionalfield", "active", ["type", "bool"]] ) :~~ ))
     extensions: (( defined( landscape.gardener.extensions ) ? validate( keys( landscape.gardener.extensions ), ["list", ["valueset", keys( landscape.versions.gardener.extensions )]] ) :~~ ))
     shootDomainPrefix: (( defined( landscape.gardener.shootDomainPrefix ) ? validate( landscape.gardener, ["optionalfield", "shootDomainPrefix", "dnslabel"] ) :~~ ))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the error if no `landscape.gardener` is defined:
```
2020/09/17 08:07:19 error generating manifest: unresolved nodes:
        (( validate(landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]]) ))    in /mounted/home/centos/SSB/landscapes/at2/landscape/crop/acre.yaml   validation.gardener.seedCandidateDeterminationStrategy  ()      *'landscape.gardener' not found                                                                                              
error classification:
 *: error in local dynaml expression
 @: dependent of or involved in a cycle
 -: depending on a node with an error
Error: processing acre.yaml
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
