### PR TITLE
add qps and burst gardenlet settings to acre.yaml

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -423,6 +423,21 @@ validation:
           - ["optionalfield", "APIServerSNI", ["type", "bool"]]
           - ["optionalfield", "KonnectivityTunnel", ["type", "bool"]]
       - - optionalfield
+        - gardenClientConnection
+        - - and
+          - ["optionalfield", "qps", ["type", "int"]]
+          - ["optionalfield", "burst", ["type", "int"]]
+      - - optionalfield
+        - seedClientConnection
+        - - and
+          - ["optionalfield", "qps", ["type", "int"]]
+          - ["optionalfield", "burst", ["type", "int"]]
+      - - optionalfield
+        - shootClientConnection
+        - - and
+          - ["optionalfield", "qps", ["type", "int"]]
+          - ["optionalfield", "burst", ["type", "int"]]
+      - - optionalfield
         - imageVectorOverwrite
         - - mapfield
           - images

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -112,8 +112,8 @@ gardenletSpec:
         gardenClientConnection:
           acceptContentTypes: application/json
           contentType: application/json
-          qps: 100
-          burst: 130
+          qps: (( configValues.config.gardenClientConnection.qps || 100 ))
+          burst: (( configValues.config.gardenClientConnection.burst || 130 ))
           gardenClusterAddress: (( .imports.kube_apiserver.export.apiserver_url ))
           gardenClusterCACert: (( base64( .imports.kube_apiserver.export.kube_apiserver_ca.cert ) ))
           bootstrapKubeconfig:
@@ -126,13 +126,13 @@ gardenletSpec:
         seedClientConnection:
           acceptContentTypes: application/json
           contentType: application/json
-          qps: 25
-          burst: 50
+          qps: (( configValues.config.seedClientConnection.qps || 25 ))
+          burst: (( configValues.config.seedClientConnection.burst || 50 ))
         shootClientConnection:
           acceptContentTypes: application/json
           contentType: application/json
-          qps: 25
-          burst: 50
+          qps: (( configValues.config.shootClientConnection.qps || 25 ))
+          burst: (( configValues.config.shootClientConnection.burst || 50 ))
         controllers:
           backupBucket:
             concurrentSyncs: 20

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -81,6 +81,21 @@ The `featureGates` field enable/disable featureGates for the gardenlet. By defau
 A list of available featureGates you can find in the gardener documentation - [Feature Gates in Gardener](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)
 
 
+## The 'gardenClientConnection' Field
+
+The `gardenClientConnection.qps` and `gardenClientConnection.burst` is to overwrite the `qps`  and `burst` default values in gardenlet-configmap - [20-componentconfig-gardenlet.yaml](https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml)
+
+
+## The 'seedClientConnection' Field
+
+The `seedClientConnection.qps` and `seedClientConnection.burst` is to overwrite the `qps`  and `burst` default values in gardenlet-configmap - [20-componentconfig-gardenlet.yaml](https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml)
+
+
+## The 'shootClientConnection' Field
+
+The `shootClientConnection.qps` and `shootClientConnection.burst` is to overwrite the `qps`  and `burst` default values in gardenlet-configmap - [20-componentconfig-gardenlet.yaml](https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml)
+
+
 ## Shooted Seeds
 
 ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `qps` and `burst` values for the gardenlet in the `landscape.iaas` in acre.yaml

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add possibility to configure gardenlet qps and burst in acre.yaml.
```
