### PR TITLE
fix ingress clusterrole

### DIFF
--- a/components/ingress-controller/chart/templates/00-ingress-controller.yaml
+++ b/components/ingress-controller/chart/templates/00-ingress-controller.yaml
@@ -65,6 +65,7 @@ rules:
       - create
       - patch
   - apiGroups:
+      - "networking.k8s.io"
       - extensions
     resources:
       - ingresses/status


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the ingress ClusterRole for `ingresses/status` in API group `networking.k8s.io`.
In the new ingress version (from #279) the apiGroup `networking.k8s.io` is required for `ingresses/status` in the ClusterRole

```
W0922 14:25:19.862404       7 status.go:279] error updating ingress rule: ingresses.networking.k8s.io "apiserver-ingress" is forbidden: User "system:serviceaccount:kube-system:nginx-ingress" cannot update resource "ingresses/status" in API group "networking.k8s.io" in the namespace "garden"
```
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Fixed a bug in the ingress ClusterRole
```
