### PR TITLE
enable custom load balancer service annotations to the ingress contro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,15 @@ identity:
 Configures the identity provider that allows access to the Gardener dashboard. The easiest method is to provide a list of `users`, each containing `email`, `username`, and either a clear-text `password` or a bcrypted `hash` of the password.
 You can then login into the dashboard using one of the specified email/password combinations.
 
+### landscape.ingress
+```yaml
+ingress:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"  # example for internal loadbalancers on aws
+    ...
+```
+
+You can add [annotations](https://github.com/gardener/garden-setup/blob/master/components/ingress-controller/chart/templates/00-ingress-controller.yaml#L249) for the ingress controller load balancer service. This can be used for example to deploy an internal load balancer on your cloud provider (see the example for aws above).
 
 ### landscape.cert-manager
 

--- a/acre.yaml
+++ b/acre.yaml
@@ -230,6 +230,8 @@ landscape:
       credentials: (( iaas[0].credentials ))
   dashboard: (( ~~ ))
   identity:
+  ingress:
+    annotations: (( ~~ ))
   gardener: (( ~~ ))
   monitoring:
     active: false

--- a/components/ingress-controller/chart/templates/00-ingress-controller.yaml
+++ b/components/ingress-controller/chart/templates/00-ingress-controller.yaml
@@ -247,6 +247,9 @@ metadata:
     heritage: Tiller
     release: addons
   annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- if .Values.dnsclass }}
     "dns.gardener.cloud/class": {{ .Values.dnsclass | quote }}
 {{- end }}

--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -40,3 +40,5 @@ ingresscontroller:
     images:
         nginx-ingress: (( .landscape.versions.ingress-controller.image_repo ":" .landscape.versions.ingress-controller.image_tag ))
         ingress-k8s-backend: (( .landscape.versions.nginx-ingress-k8s-backend.image_repo ":" .landscape.versions.nginx-ingress-k8s-backend.image_tag ))
+    ingress:
+      annotations: (( .landscape.ingress.annotations || ~~ ))


### PR DESCRIPTION
…ller via acre.yaml

**What this PR does / why we need it**:
This change enables you to modify the ingress controller load balancer service annotations via the acre.yaml.

**Which issue(s) this PR fixes**: #298 

**Special notes for your reviewer**:

**Release note**:

```improvement operator
add annotations to the the ingress controller load balancer service via acre.yaml
```
