### PR TITLE
customize the settings for the seeds via acre.yaml

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -76,6 +76,7 @@ seedSpec:
     services: (( configValues.seed.networks.services ))
     shootDefaults: (( configValues.seed.shootDefaultNetworks || { "pods" = "100.96.0.0/11", "services" = "100.64.0.0/13" } ))
   taints: (( configValues.config.mode == "soil" ? [{ "key" = "seed.gardener.cloud/invisible" }, { "key" = "seed.gardener.cloud/protected" }] :~~ ))
+  settings: (( configValues.seed.settings || ~~ ))
 
 gardenletBootstrapKubeconfig:
   apiVersion: v1

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -70,6 +70,7 @@ providerconfig:
     ingressdomain: (( name "." .imports.ingress_dns.export.ingress_domain ))
     networks: (( v.cluster.networks || landscape.clusters.[0].networks ))
     shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
+    settings: (( v.seedSettings || ~~ ))
   secretname: (( name "-" v.mode ))
 
 renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -33,6 +33,15 @@ iaas:
             pods: <CIDR IP range>
             services: <CIDR IP range>
             <additional fields depending on type>
+    seedSettings:                                    # settings for the seed
+      excessCapacityReservation:
+        enabled: true
+      scheduling:
+        visible: true
+      shootDNS:
+        enabled: true
+      verticalPodAutoscaler:
+        enabled: true
       ...
   - name:                                        # see above
     mode: <seed|cloudprofile|profile|inactive>   # what should be deployed
@@ -80,6 +89,9 @@ Cloudprofiles are created first, before any seed. Thus, entries of `landscape.ia
 The `featureGates` field enable/disable featureGates for the gardenlet. By default - that means there is no `featureGates` field or no value for `featureGates.Logging` - the `Logging` featureGate will be enabled. To diasble the `Logging` featureGate you have to set the `featureGates.Logging` to `false`.
 A list of available featureGates you can find in the gardener documentation - [Feature Gates in Gardener](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)
 
+## The 'seedSettings' Field
+
+The `seedSettings` field let you modify the settings for you seed for further customization. See [here](https://github.com/gardener/gardener/blob/master/docs/usage/seed_settings.md#settings-for-seeds) the documentation.
 
 ## The 'gardenClientConnection' Field
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With the given changes you can modify the settings of the seeds via the `acre.yaml` in the `landscape.iaas` sections. We need to modify these settings to set our shoot api load balancers to internal.

**Which issue(s) this PR fixes**: none

**Special notes for your reviewer**:

**Release note**:
```improvement operator
modify seed settings via acre.yaml
```
