### PR TITLE
make Gardener resource requests/limits configurable

### DIFF
--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -92,6 +92,37 @@ garden_secret:
 
 gardener_version: (( &temporary ( .landscape.versions.gardener ) ))
 
+default_resources:
+  <<: (( &temporary ))
+  apiserver:
+    limits:
+      cpu: 300m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  admission:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      cpu: 300m
+      memory: 512Mi
+  controller:
+    limits:
+      cpu: 750m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  scheduler:
+    limits:
+      cpu: (( ~~ ))
+      memory: (( ~~ ))
+    requests:
+      cpu: (( ~~ ))
+      memory: (( ~~ ))
+
 gardener:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   source: "git/repo/charts/gardener/controlplane/charts/application"
@@ -119,13 +150,7 @@ gardener:
           tag: (( .gardener_version.apiserver.image_tag || ~~ ))
         insecureSkipTLSVerify: false
         replicaCount: 1
-        resources:
-          limits:
-            cpu: 300m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        resources: (( merge( default_resources.apiserver, ( landscape.gardener.resources.apiserver || {} ) ) ))
         serviceAccountName: gardener-apiserver
         tls:
           crt: (( .state.gardener_apiserver.value.cert ))
@@ -140,13 +165,7 @@ gardener:
           pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
           repository: (( .gardener_version.admission_controller.image_repo ))
           tag: (( .gardener_version.admission_controller.image_tag || ~~ ))
-        resources:
-          requests:
-            cpu: 100m
-            memory: 200Mi
-          limits:
-            cpu: 300m
-            memory: 512Mi
+        resources: (( merge( default_resources.admission, ( landscape.gardener.resources.admission || {} ) ) ))
         vpa: false
         config:
           gardenClientConnection:
@@ -224,13 +243,7 @@ gardener:
           repository: (( .gardener_version.controller_manager.image_repo ))
           tag: (( .gardener_version.controller_manager.image_tag || ~~ ))
         replicaCount: 1
-        resources:
-          limits:
-            cpu: 750m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        resources: (( merge( default_resources.controller, ( landscape.gardener.resources.controller || {} ) ) ))
         serviceAccountName: gardener-controller-manager
       scheduler:
         image:
@@ -238,6 +251,7 @@ gardener:
           repository: (( .gardener_version.scheduler.image_repo ))
           tag: (( .gardener_version.scheduler.image_tag || ~~ ))
         serviceAccountName: gardener-scheduler
+        resources: (( merge( default_resources.scheduler, ( landscape.gardener.resources.scheduler || {} ) ) ))
         config:
           schedulers:
             shoot:

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -56,3 +56,25 @@ Example to set the `imageVectorOverwrite` (see [values.yaml](https://github.com/
 
 #### Change default shoot prefix domain
 Per default all shoot api server domains are something like '<clustername>.<project>.shoot.<basedomain>'. If you want to change the 'shoot' term you can use `landscape.gardener.shootDomainPrefix` and set a value you like.  
+
+
+### Resources
+
+It is possible to overwrite the default values for the resource requests/limits of the Gardener components by setting the corresponding values in `landscape.gardener.resources`.
+```yaml
+  ...
+  gardener:
+    ...
+    resources:
+      apiserver:
+        limits:
+          cpu: 300m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      admission: <see above>
+      controller: <see above>
+      scheduler: <see above>
+```
+All fields are optional.


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a working implementation for #342 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Resource requests and limits for the Gardener components are now configurable in the acre.yaml
```
