### PR TITLE
Update extensions and dashboard

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,19 +28,19 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.17.2"
+          "version": "v1.19.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.15.4"
+          "version": "v1.17.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.13.1"
+          "version": "v1.14.0"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.13.0"
+          "version": "v1.15.0"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
@@ -52,14 +52,14 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.4.1"
+          "version": "v0.5.0"
         }
       }
     },
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.47.0"
+        "version": "1.48.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Gardener extensions and dashboard to the newest versions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade Gardener extension provider-aws to `v1.19.0`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.14.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.17.0`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.15.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.5.0`
```
```noteworthy operator
Upgrade Gardener dashboard to `1.48.0`
```
