### PR TITLE
restore ability to configure nginx service annotations in acre.yaml

### DIFF
--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -70,6 +70,7 @@ ingresscontroller:
           "dns.gardener.cloud/class": (( imports.dns-controller.export.dns-class ))
           "dns.gardener.cloud/dnsnames": (( "*." .settings.ingress_domain ))
           "dns.gardener.cloud/ttl": (( landscape.defaultTTL ))
+          <<: (( landscape.ingress.annotations || ~ ))
       admissionWebhooks:
         enabled: false
       extraArgs:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
It is now possible again to configure the nginx service annotations in the acre.yaml.
```
