### PR TITLE
use seed managed ingress feature instead of shoot addon

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -54,7 +54,7 @@ secretManifests:
   apiVersion: v1
   kind: Secret
   metadata:
-    name: ingress-dns-secret
+    name: (( configValues.secretname "-ingress-dns-secret" ))
     namespace: (( configValues.namespace ))
   type: Opaque
   data:
@@ -97,7 +97,7 @@ ingressTemplate:
       provider:
         type: (( configValues.dns.type ))
         secretRef:
-          name: ingress-dns-secret
+          name: (( configValues.secretname "-ingress-dns-secret" ))
           namespace: (( configValues.namespace ))
     ingress:
       domain: (( configValues.seed.ingressdomain ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -50,6 +50,15 @@ secretManifests:
     token-secret: (( configValues.bootstrapToken.secret ))
     usage-bootstrap-authentication: "true"
     usage-bootstrap-signing: "true"
+- <<: (( configValues.isBaseCluster ? ~~ :~ ))
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ingress-dns-secret
+    namespace: (( configValues.namespace ))
+  type: Opaque
+  data:
+    <<: (( sum[configValues.dns.credentials|{}|ss,sk,sv|-> ss { sk = base64(sv) }] ))
 
 seedSpec:
   <<: (( &temporary ))
@@ -65,8 +74,8 @@ seedSpec:
     secretRef:
       name: (( configValues.secretname "-backup" ))
       namespace: (( configValues.namespace ))
-  dns:
-    ingressDomain: (( configValues.seed.ingressdomain ))
+  dns: (( configValues.isBaseCluster ? ingressTemplate.baseCluster.dns :ingressTemplate.default.dns ))
+  ingress: (( configValues.isBaseCluster ? ~~ :ingressTemplate.default.ingress ))
   secretRef:
     name: (( configValues.secretname ))
     namespace: (( configValues.namespace ))
@@ -77,6 +86,23 @@ seedSpec:
     shootDefaults: (( configValues.seed.shootDefaultNetworks || { "pods" = "100.96.0.0/11", "services" = "100.64.0.0/13" } ))
   taints: (( configValues.config.mode == "soil" ? [{ "key" = "seed.gardener.cloud/protected" }] :~~ ))
   settings: (( element( merge( seedSettingMergeTemplate, configValues.seed || {} ), "settings" ) ))
+
+ingressTemplate:
+  <<: (( &temporary ))
+  baseCluster:
+    dns:
+      ingressDomain: (( configValues.seed.ingressdomain ))
+  default:
+    dns:
+      provider:
+        type: (( configValues.dns.type ))
+        secretRef:
+          name: ingress-dns-secret
+          namespace: (( configValues.namespace ))
+    ingress:
+      domain: (( configValues.seed.ingressdomain ))
+      controller:
+        kind: nginx
 
 seedSettingMergeTemplate:
   <<: (( &template &temporary ))

--- a/components/gardencontent/seeds/manifests/shoot_manifest.yaml
+++ b/components/gardencontent/seeds/manifests/shoot_manifest.yaml
@@ -49,7 +49,7 @@ spec:
     enabled: false
   addons:
     nginxIngress:
-      enabled: true
+      enabled: false
     kubernetesDashboard:
       enabled: false
 

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -44,6 +44,7 @@ providerconfig:
   namespace: (( landscape.namespace ))
   dns:
     type: (( landscape.dns.type ))
+    credentials: (( landscape.dns.credentials ))
   iaas: (( read(__ctx.DIR "/../provider/" v.type "/seed.yaml", "import") ))
   config: (( v ))
   isBaseCluster: false

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -55,6 +55,7 @@ providerconfig:
   namespace: (( landscape.namespace ))
   dns:
     type: (( landscape.dns.type ))
+    credentials: (( landscape.dns.credentials ))
   iaas: (( read(__ctx.DIR "/../provider/" v.type "/seed.yaml", "import") ))
   config: (( v ))
   isBaseCluster: (( ! valid( v.cluster.kubeconfig ) ))


### PR DESCRIPTION
**What this PR does / why we need it**:
The nginx shoot addon in Gardener is deprecated. For shooted seeds, the managed ingress feature is the better way to get an nginx into the cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Replace nginx shoot addon with managed ingress feature for shooted seeds. The behaviour when deploying over an existing landscape has not been tested. In theory, this should work, although you might experience a downtime of the seeds. This change should not cause any problems for new landscapes and for landscapes without shooted seeds created by garden-setup.
```
