### PR TITLE
fix dns-controller-manager configuration

### DIFF
--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -102,5 +102,5 @@ spec:
       dnsClass: (( common.dns_class ))
       identifier: (( "setup.gardener.cloud/" .landscape.name ))
       kubeconfigId: (( .landscape.name ))
-      controllers: (( "dnssources," dns.type ( cname.type != dns.type ? "," cname.type :"" ) ))
+      controllers: "dnssources,compound"
       ttl: (( .landscape.dns.ttl || ~~ ))


### PR DESCRIPTION
Adapts the dns-controller-manager configuration to version `v0.8.0`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
