### PR TITLE
dns provider infoblox: optional fields for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ The credentials to use Cloudflare DNS consist of a single key `apiToken`, contai
 
 #### Infoblox Credentials and Configuration
 
-For Infoblox DNS, you have to specify `USERNAME` and `PASSWORD` in the `credentials` node.
-Additionally, a `host` and a `version` need to be specified, both under `landscape.dns.providerConfig`. See [here](https://github.com/gardener/external-dns-management/blob/master/doc/infoblox/README.md#create-dns-provider) for further information on optional configuration fields that can also be specified in `landscape.dns.providerConfig`.
+For Infoblox DNS, you have to specify `USERNAME`, `PASSWORD`, and `HOST` in the `credentials` node.
+Additionally, a `host` needs to be specified, both under `landscape.dns.providerConfig`. See [here](https://github.com/gardener/external-dns-management/blob/master/doc/infoblox/README.md#create-dns-provider) for further information on optional configuration fields that can also be specified in `landscape.dns.providerConfig`.
 
 
 ### landscape.identity

--- a/acre.yaml
+++ b/acre.yaml
@@ -499,6 +499,15 @@ validation:
           - and
           - ["mapfield", "USERNAME"]
           - ["mapfield", "PASSWORD"]
+          - ["mapfield", "HOST", ["ip"]]
+          - ["optionalfield", "PORT", ["type", "int"]]
+          - ["optionalfield", "SSL_VERIFY", ["type", "bool"]]
+          - ["optionalfield", "VERSION"]
+          - ["optionalfield", "VIEW"]
+          - ["optionalfield", "HTTP_POOL_CONNECTIONS", ["type", "int"]]
+          - ["optionalfield", "HTTP_REQUEST_TIMEOUT", ["type", "int"]]
+          - ["optionalfield", "CA_CERT", ["ca"]]
+          - ["optionalfield", "PROXY_URL"]
         config:
           - mapfield
           - providerConfig
@@ -506,7 +515,7 @@ validation:
             - ["mapfield", "host", ["ip"]]
             - ["optionalfield", "port", ["type", "int"]]
             - ["optionalfield", "sslVerify", ["type", "bool"]]
-            - ["mapfield", "version"]
+            - ["optionalfield", "version"]
             - ["optionalfield", "view"]
             - ["optionalfield", "httpPoolConnections", ["type", "int"]]
             - ["optionalfield", "httpRequestTimeout", ["type", "int"]]


### PR DESCRIPTION
**What this PR does / why we need it**:
For the DNSProvider infoblox the credentials must include a `HOST` and can include some more optional fields, as the providerConfig is currently not handled in Gardener on creating internal/external DNSProviders.
The `version` field has been marked as optional.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
dns provider infoblox: optional fields for credentials
```
