### PR TITLE
Upgrade Gardener, Dashboard and extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -703,6 +703,30 @@ validation:
     selfsigned: (( |ca,url|-> [url == "self-signed" ? valid( ca.crt ) -and valid( ca.key ) :true, "valid", "if 'landscape.cert-manager.server.url' is set to 'self-signed', you should either specify a CA with key ('server.ca.crt' and 'server.ca.key' set), or no CA at all ('server.ca' node not present)"] ))
     acme: (( |ca,url|-> [url != "self-signed" ? valid( ca.crt ) -and ( ! defined( ca.key ) ) :true, "if 'landscape.cert-manager.server.url' is not set to 'self-signed', you should either specify a CA without key ('server.ca.crt' set, no 'server.ca.key'), or the 'server.ca' node should not be present at all"] ))
     email: (( |ca,id|-> [valid( ca.email ) -or valid( id.users[0].email ), "either 'landscape.cert-manager.email' or 'landscape.identity.users[0].email' needs to be set"] ))
+  identity_validator:
+    - and
+    - - optionalfield
+      - users
+      - - list
+        - - and
+          - - mapfield
+            - email
+            - - match
+              - (( validation.email_regex ))
+          - - mapfield
+            - username
+          - - or
+            - ["mapfield", "password"]
+            - ["mapfield", "hash"]
+    - - optionalfield
+      - connectors
+      - - list
+        - - and
+          - ["mapfield", "type"]
+          - ["mapfield", "id"]
+          - ["mapfield", "name"]
+    - ["optionalfield", "allowProjectCreationForAll", ["type", "bool"]]
+    - ["optionalfield", "useIdentityDomain", ["type", "bool"]]
 
 
   ### VALIDATIONS ###
@@ -743,21 +767,5 @@ validation:
   cert-manager: (( validate( landscape.cert-manager, validation.cert-manager_validators.basic, [validation.cert-manager_validators.email, landscape.identity] ) ))
   ##### landscape.identity TODO
   identity:
-    userspec:
-      - and
-      - - mapfield
-        - email
-        - - match
-          - (( validation.email_regex ))
-      - - mapfield
-        - username
-      - - or
-        - ["mapfield", "password"]
-        - ["mapfield", "hash"]
-    connectorspec:
-      - and
-      - ["mapfield", "type"]
-      - ["mapfield", "id"]
-      - ["mapfield", "name"]
     identityspec: (( |id|-> [valid( id.users || id.connectors ), "valid", "identity config needs to contain either 'users' or 'connectors' (or both)"] ))
-    validator: (( validate( landscape.identity, identityspec, ["optionalfield", "users", ["list", identity.userspec]], ["optionalfield", "connectors", ["list", identity.connectorspec]] ) ))
+    validator: (( validate( landscape.identity, identityspec, validation.identity_validator ) ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -160,6 +160,10 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: User
     name: (( user ))
+  authenticatedGroup:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "system:authenticated"
   users: (( map[.landscape.identity.users|v|->v.email]))
 
 rbac:
@@ -173,7 +177,9 @@ rbac:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: gardener.cloud:system:project-creation
-      subjects: (( util.userbindings(spec.users) ))
+      subjects:
+        - <<: (( util.userbindings(spec.users) ))
+        -  (( ( .landscape.identity.allowProjectCreationForAll || false ) ? .spec.authenticatedGroup :~~ ))
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -51,17 +51,19 @@ defaults:
   kubernetes:
     versions:
       - classification: supported
+        version: 1.20.2
+      - classification: supported
+        version: 1.19.6
+      - classification: deprecated
         version: 1.19.4
-      - classification: deprecated
-        version: 1.19.3
       - classification: supported
+        version: 1.18.14
+      - classification: deprecated
         version: 1.18.12
-      - classification: deprecated
-        version: 1.18.10
       - classification: supported
-        version: 1.17.14
+        version: 1.17.16
       - classification: deprecated
-        version: 1.17.13
+        version: 1.17.14
       - version: 1.16.15
         classification: deprecated
       - version: 1.15.12

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.17.0"
+        "version": "v1.17.1"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.16.0"
+          "version": "v1.16.1"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.16.2"
+        "version": "v1.17.0"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.20.3"
+          "version": "v1.20.4"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.10.2"
+          "version": "v1.11.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.20.4"
+          "version": "v1.20.5"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -59,7 +59,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.48.1"
+        "version": "1.49.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -68,7 +68,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.14.0"
+          "version": "v0.15.0"
         }
       }
     }

--- a/docs/extended/identity.md
+++ b/docs/extended/identity.md
@@ -56,3 +56,5 @@ The issuer URL can be set via `landscape.identity.issuerUrl`. The default is `ht
 By setting `landscape.identity.dashboardClientSecret` or `landscape.identity.kubectlClientSecret`, the corresponding client secret(s) can be defined. By default, a random value is generated for the first deployment, which is then stored in the state so it doesn't change on redeployments.
 
 It is possible to create additional users with static passwords but without privileges by providing a list of users in `landscape.identity.unprivilegedUsers`. The syntax is the same as for `landscape.identity.users`. There has to be at least one entry in `lansdcape.identity.users` for this list to be evaluated.
+
+To allow project creation for all authenticated users, set `landscape.identity.allowProjectCreationForAll` to `true`.


### PR DESCRIPTION
Fixes #53 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Upgrade Gardener to `v1.17.1`
```
```noteworthy operator
Upgrade Gardener dashboard to `1.49.0`
```
```noteworthy operator
Update default kubernetes versions in cloudprofile
```
```feature operator
It is now possible to enable project creation for all authenticated users by setting `landscape.identity. allowProjectCreationForAll` to `true`.
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.16.1`
```
```other operator
Upgrade terminal-controller-manager to `v0.15.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.20.5`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.11.0`
```
