### PR TITLE
use credentials instead of providerConfig for infoblox DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,7 @@ The credentials to use Cloudflare DNS consist of a single key `apiToken`, contai
 
 #### Infoblox Credentials and Configuration
 
-For Infoblox DNS, you have to specify `USERNAME`, `PASSWORD`, and `HOST` in the `credentials` node.
-Additionally, a `host` needs to be specified, both under `landscape.dns.providerConfig`. See [here](https://github.com/gardener/external-dns-management/blob/master/doc/infoblox/README.md#create-dns-provider) for further information on optional configuration fields that can also be specified in `landscape.dns.providerConfig`.
-
+For Infoblox DNS, you have to specify `USERNAME`, `PASSWORD`, and `HOST` in the `credentials` node. For a complete list of optional credentials keys see [here](https://github.com/gardener/external-dns-management/tree/master/docs/infoblox#create-secret-with-infoblox-credentials)
 
 ### landscape.identity
 ```yaml

--- a/acre.yaml
+++ b/acre.yaml
@@ -508,20 +508,22 @@ validation:
           - ["optionalfield", "HTTP_REQUEST_TIMEOUT", ["type", "int"]]
           - ["optionalfield", "CA_CERT", ["ca"]]
           - ["optionalfield", "PROXY_URL"]
-        config:
-          - mapfield
-          - providerConfig
-          - - and
-            - ["mapfield", "host", ["ip"]]
-            - ["optionalfield", "port", ["type", "int"]]
-            - ["optionalfield", "sslVerify", ["type", "bool"]]
-            - ["optionalfield", "version"]
-            - ["optionalfield", "view"]
-            - ["optionalfield", "httpPoolConnections", ["type", "int"]]
-            - ["optionalfield", "httpRequestTimeout", ["type", "int"]]
-            - ["optionalfield", "caCert", ["ca"]]
-            - ["optionalfield", "maxResults", ["type", "int"]]
-            - ["optionalfield", "proxyUrl"]
+        config: (( return_true ))
+# providerConfig support not complete in Gardener
+#        config:
+#          - mapfield
+#          - providerConfig
+#          - - and
+#            - ["mapfield", "host", ["ip"]]
+#            - ["optionalfield", "port", ["type", "int"]]
+#            - ["optionalfield", "sslVerify", ["type", "bool"]]
+#            - ["optionalfield", "version"]
+#            - ["optionalfield", "view"]
+#            - ["optionalfield", "httpPoolConnections", ["type", "int"]]
+#            - ["optionalfield", "httpRequestTimeout", ["type", "int"]]
+#            - ["optionalfield", "caCert", ["ca"]]
+#            - ["optionalfield", "maxResults", ["type", "int"]]
+#            - ["optionalfield", "proxyUrl"]
   iaas_entry_validators:
     basic:
       - <<: (( &template ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener does not yet support providerConfig for its internal/external DNSProvider.
Therefore credentials fields must be used instead for infoblox DNS

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator

```
