### PR TITLE
fix bug when deactivating etcd backups for GCS

### DIFF
--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -95,7 +95,7 @@ etcd:
         secretData: (( sum[temp.config.credentials|{}|c,k,v|->c {k=base64(v)}] ))
         storageContainer: (( landscape.etcd.backup.active ? imports.backupinfra.export.bucketname :~ ))
         env: (( temp.addon.env ))
-        volumeMounts: (( temp.addon.volumeMounts ))
+        volumeMounts: (( landscape.etcd.backup.active ? temp.addon.volumeMounts :[] ))
 
       tls:
         ca:


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug that occurred when trying to deactivate backups which would otherwise have been stored in a GCS bucket.
```
