### PR TITLE
Fix 430 ingress competing gcp lb

### DIFF
--- a/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
+++ b/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
@@ -17,6 +17,7 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    kubernetes.io/ingress.class: "nginx"
   name: apiserver-ingress
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes #430 by adding ingress.class annotation to the api-server ingress definition
**Which issue(s) this PR fixes**:
#430 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fixes #430 by adding ingress.class annotation to the api-server ingress definition
```
