### PR TITLE
bugfix: landscape.identity.users not defined

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -164,7 +164,7 @@ spec:
     apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: "system:authenticated"
-  users: (( map[.landscape.identity.users|v|->v.email]))
+  users: (( valid( landscape.identity.users ) ? map[.landscape.identity.users|v|->v.email] :[] ))
 
 rbac:
   kubeconfig: (( imports.kube_apiserver.export.kubeconfig ))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug that caused the dashboard component to fail if `landscape.identity.users` was not defined.

**Which issue(s) this PR fixes**:
#438 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug that caused the dashboard component to fail if `landscape.identity.users` was not defined.
```
