### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -51,19 +51,21 @@ defaults:
   kubernetes:
     versions:
       - classification: supported
+        version: 1.20.4
+      - classification: deprecated
         version: 1.20.2
       - classification: supported
+        version: 1.19.8
+      - classification: deprecated
         version: 1.19.6
-      - classification: deprecated
-        version: 1.19.4
       - classification: supported
+        version: 1.18.16
+      - classification: deprecated
         version: 1.18.14
-      - classification: deprecated
-        version: 1.18.12
       - classification: supported
-        version: 1.17.16
+        version: 1.17.17
       - classification: deprecated
-        version: 1.17.14
+        version: 1.17.16
       - version: 1.16.15
         classification: deprecated
       - version: 1.15.12

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -218,6 +218,8 @@ gardenletSpec:
         featureGates: 
           <<: (( configValues.config.featureGates || {} ))
           Logging: (( configValues.config.featureGates.Logging || true ))
+          ManagedIstio: (( pluginSpecs.managedIstioActive ))
+          APIServerSNI: (( configValues.config.featureGates.APIServerSNI || false ))
         seedConfig:
           metadata:
             name: (( configValues.name ))
@@ -228,6 +230,7 @@ gardenletSpec:
         enabled: true
 
 pluginSpecs:
+  managedIstioActive: (( configValues.config.featureGates.ManagedIstio || false ))
   deploySecrets:
     kubeconfig: (( configValues.kubeconfigs.virtual ))
     manifests: (( secretManifests ))
@@ -256,6 +259,16 @@ pluginSpecs:
     step: delete
     type: seed
     name: (( configValues.name ))
+  deleteIstioIngressNamespace:
+    kubeconfig: (( configValues.kubeconfigs.seed ))
+    step: delete
+    type: namespace
+    name: "istio-ingress"
+  deleteIstioSystemNamespace:
+    kubeconfig: (( configValues.kubeconfigs.seed ))
+    step: delete
+    type: namespace
+    name: "istio-system"
   deleteBootstrapToken:
     # delete duplicate bootstrap tokens that are created during re-deployment
     kubeconfig: (( configValues.kubeconfigs.virtual ))

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -24,6 +24,10 @@ plugins:
 pluginTemplate:
   - <<: (( &temporary &template ))
   - kubectl: (( "renderedPluginSpecs[" id "].deploySecrets" ))
+  - parallel:
+    - <<: (( renderedPluginSpecs[id].managedIstioActive == true ? ~ :~~ ))
+    - delete: (( "renderedPluginSpecs[" id "].deleteIstioIngressNamespace" ))
+    - delete: (( "renderedPluginSpecs[" id "].deleteIstioSystemNamespace" ))
   - (( valid( renderedPluginSpecs[id].namespace ) ? { "kubectl" = "renderedPluginSpecs[" id "].namespace" } :~~ ))
   - pinned:
     - helm:

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -24,6 +24,10 @@ plugins:
 pluginTemplate:
   - <<: (( &temporary &template ))
   - kubectl: (( "renderedPluginSpecs[" id "].deploySecrets" ))
+  - parallel:
+    - <<: (( renderedPluginSpecs[id].managedIstioActive == true ? ~ :~~ ))
+    - delete: (( "renderedPluginSpecs[" id "].deleteIstioIngressNamespace" ))
+    - delete: (( "renderedPluginSpecs[" id "].deleteIstioSystemNamespace" ))
   - (( valid( renderedPluginSpecs[id].namespace ) ? { "kubectl" = "renderedPluginSpecs[" id "].namespace" } :~~ ))
   - pinned:
     - helm:

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.19.2"
+        "version": "v1.20.3"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.16.2"
+          "version": "v1.17.1"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.8.1"
+          "version": "v0.8.2"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.18.1"
+          "version": "v1.19.1"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Upgrade Gardener to `v1.20.3`
```
```noteworthy operator
The default kubernetes versions in the cloudprofile have been updated.
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.17.1`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.19.1`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.8.2`
```
```noteworthy operator
Starting with version `v1.20`, Gardener deploys a managed istio into each seed cluster. This behaviour is deactivated in garden-setup by default. To activate the managed istio for a seed, add `featureGates.ManagedIstio: true` and `featureGates.APIServerSNI: true` to that seed's `landscape.iaas` entry. Please be aware that there currently is no easy way of removing istio again - if a seed with the feature gate active is deleted, the istio namespaces will be removed, but cluster-scoped resources and resources in other namespaces will be leaked in your cluster. This shouldn't be a big problem for shooted seeds though, as they will be gone when the shoot is deleted.
```