### PR TITLE
upgrade terraform manifests to terraform 0.13

### DIFF
--- a/components/etcd/backupinfra/provider/abs/versions.tf
+++ b/components/etcd/backupinfra/provider/abs/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
 }

--- a/components/etcd/backupinfra/provider/gcs/versions.tf
+++ b/components/etcd/backupinfra/provider/gcs/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }

--- a/components/etcd/backupinfra/provider/s3/versions.tf
+++ b/components/etcd/backupinfra/provider/s3/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/components/etcd/backupinfra/provider/swift/versions.tf
+++ b/components/etcd/backupinfra/provider/swift/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The openstack terraform provider for terraform <0.13 doesn't exist anymore.

**Special notes for your reviewer**:
This requires a `sow` release containing https://github.com/gardener/sow/pull/43

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The terraform modules for creation of the etcd backup bucket have been adapted for terraform 0.13
```
```breaking operator
⚠️ Due to the updated terraform plugins, this version of garden-setup requires terraform `0.13` or higher. If the `sow` image is used, version `3.3.0` or higher of `sow` is required.
```