### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/components/dns-controller/manifests/provider_secret.yaml
+++ b/components/dns-controller/manifests/provider_secret.yaml
@@ -18,4 +18,6 @@ metadata:
   name: (( values.secret_name ))
   namespace: (( values.namespace ))
 type: Opaque
-data: (( sum[values.provider.credentials|{}|c,k,v|->c {k=base64(v)}] ))
+data:
+  <<: (( sum[values.provider.credentials|{}|c,k,v|->c {k=base64(v)}] ))
+  OS_AUTH_URL: (( values.provider.name == "openstack" ? authURL || ~~ :~~ ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.17.1"
+          "version": "v1.18.0"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.9.0"
+          "version": "v1.10.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.16.0"
+          "version": "v1.17.0"
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.22.2"
+          "version": "v1.23.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.6.0"
+          "version": "v0.7.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.20.3"
+        "version": "v1.21.0"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.8.2"
+          "version": "v0.8.3"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #348 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Upgrade Gardener to `v1.21.0`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.18.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.23.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.7.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.17.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.10.0`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.8.3`
```
```bugfix operator
Fixed a bug that created an invalid DNS secret for the openstack-designate DNS service.
```