### PR TITLE
Upgrade Gardener and dependencies

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -45,9 +45,12 @@ dashboard:
     apiServerUrl: (( imports.kube_apiserver.export.apiserver_url ))
     apiServerCa: (( imports.kube_apiserver.export.kube_apiserver_ca.cert ))
     sessionSecret: (( rand("[:alnum:]", 30) ))
-    hosts:
-      - (( imports.identity.export.dashboard_dns ))
-      - (( .landscape.dashboard.cname.domain || ~~ ))
+    ingress:
+      tls:
+        secretName: (( imports.cert.export.certificate.secret_name ))
+      hosts:
+        - (( imports.identity.export.dashboard_dns ))
+        - (( .landscape.dashboard.cname.domain || ~~ ))
     image:
       repository: (( .dashboard_version.image_repo || ~~ ))
       tag: (( .dashboard_version.image_tag || ~~ ))
@@ -60,8 +63,6 @@ dashboard:
       public:
         clientId: kube-kubectl
         clientSecret: (( imports.identity.export.kubectlClientSecret ))
-    tlsSecretName: (( imports.cert.export.certificate.secret_name ))
-    tls: ~
     kubeconfig: (( format( "((!!! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
     podLabels:
       <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.20.0"
+          "version": "v1.20.1"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.8.3"
+          "version": "v0.9.0"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.19.1"
+          "version": "v1.20.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.18.0"
+          "version": "v1.19.0"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.23.0"
+          "version": "v1.24.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -68,7 +68,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.15.0"
+          "version": "v0.16.0"
         }
       }
     }

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.7.1"
+          "version": "v0.9.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -59,7 +59,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.49.0"
+        "version": "1.50.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.16.0"
+          "version": "v1.16.2"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.10.0"
+          "version": "v1.12.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.12.0"
+          "version": "v1.13.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.21.0"
+        "version": "v1.23.0"
       },
       "extensions": {
         "dns-external": {


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Upgrade Gardener dashboard to `1.50.0`
```
```noteworthy operator
Upgrade Gardener to `v1.23.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.20.1`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.16.2`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.19.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.12.0`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.13.0`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.9.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.9.0`
```
```other operator
Upgrade Gardener terminal-controller-manager to `v0.16.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.24.0`
```
