### PR TITLE
Set correct terminal controller sidecar image replacement

### DIFF
--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -88,7 +88,7 @@ kustomize:
       args:
         - set
         - image
-        - (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? ( "gcr.io/kubebuilder/kube-rbac-proxy=" .landscape.versions.terminal-kube-rbac-proxy.image_repo ":" ( .landscape.versions.terminal-kube-rbac-proxy.image_tag || "latest" ) ) :~~ ))
+        - (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? ( "quay.io/brancz/kube-rbac-proxy=" .landscape.versions.terminal-kube-rbac-proxy.image_repo ":" ( .landscape.versions.terminal-kube-rbac-proxy.image_tag || "latest" ) ) :~~ ))
     render:
       path: (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? env.GENDIR "/kustomize.runtime.edit-rbac-image/edit" :env.GENDIR "/kustomize.runtime.edit-tcm-image/edit" ))
       kustomization: "config/overlay/multi-cluster/runtime"


### PR DESCRIPTION
**What this PR does / why we need it**:
The terminal controller sidecar kube-rbac-proxy image has changed and will not get replaced with acre versions. So image to be replaced is changed to `quay.io/brancz/kube-rbac-proxy`.

**Release note**:
```bugfix operator
Sidecar image for terminal controller can be replaced through acre versions.
```
