### PR TITLE
Fix a bug in deployment of gardener-metrics-exporter

### DIFF
--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -78,7 +78,7 @@ helm:
     kubeconfig: (( format( "((!!! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
 
 settings:
-  dashboard_path_prefix: (( env.GENDIR "/git/repo/dashboards/" ))
+  dashboard_path_prefix: (( env.GENDIR "/git/repo/dashboards" ))
   serviceaccount_name: gardener-metrics-exporter
   excluded_dashboards:
     - shoot-state-overview-dashboard.json
@@ -86,7 +86,7 @@ settings:
 patch:
   <<: (( &temporary ))
   deploy:
-    data: (( sum[list_files( .settings.dashboard_path_prefix )|{}|s,f|-> contains( .settings.excluded_dashboards, f ) ? s :s { f = read( .settings.dashboard_path_prefix f, "text" ) }] ))
+    data: (( sum[list_files( .settings.dashboard_path_prefix )|{}|s,f|-> contains( .settings.excluded_dashboards, f ) ? s :s { f = read( .settings.dashboard_path_prefix "/" f, "text" ) }] ))
   delete:
     data: (( sum[list_files( .settings.dashboard_path_prefix )|{}|s,f|-> contains( .settings.excluded_dashboards, f ) ? s :s { f = "null" }] ))
   


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in the deployment of gardener-metrics-exporter. 

```
*** sowing species monitoring/gardener-metrics-exporter
using local action script
executing configured plugins for action prepare
using config from path git
Plugin: git[prepare] (/sow/plugins/git/plugin)
2021/07/05 13:49:25 error parsing template [-]: yaml: [while scanning a simple key] could not find expected ':' at line 3, column 122669
Error: saving deployment.yaml
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug in deployment of gardener-metrics-exporter
```
