### PR TITLE
Upgrade Gardener, extensions, kubernetes versions and machine images

### DIFF
--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -33,14 +33,14 @@ defaults:
       - <<: (( defaults.providerspec.machineImages || ~ ))
       - name: gardenlinux
         versions:
+        - version: 318.8.0
         - version: 184.0.0
-        - version: 27.1.0
       - name: ubuntu
         versions:
         - version: 18.4.20200228
       - name: suse-chost
         versions:
-        - version: 15.2.20201016
+        - version: 15.2.20210610
     machineTypes:
       - <<: (( defaults.providerspec.machineTypes || ~ ))
     volumeTypes:

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -50,22 +50,22 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
+      - classification: preview
+        version: 1.21.2
       - classification: supported
+        version: 1.20.6
+      - classification: deprecated
         version: 1.20.4
-      - classification: deprecated
-        version: 1.20.2
       - classification: supported
+        version: 1.19.10
+      - classification: deprecated
         version: 1.19.8
-      - classification: deprecated
-        version: 1.19.6
       - classification: supported
-        version: 1.18.16
+        version: 1.18.18
       - classification: deprecated
-        version: 1.18.14
+        version: 1.18.16
       - classification: supported
         version: 1.17.17
-      - classification: deprecated
-        version: 1.17.16
       - version: 1.16.15
         classification: deprecated
       - version: 1.15.12

--- a/components/gardencontent/profiles/provider/aws/iaas.yaml
+++ b/components/gardencontent/profiles/provider/aws/iaas.yaml
@@ -21,6 +21,42 @@ providerConfig:
   - name: gardenlinux
     versions:
     - regions:
+      - ami: ami-077967ddf49bd7822
+        name: eu-north-1
+      - ami: ami-07f7b310124c898e1
+        name: ap-south-1
+      - ami: ami-00e17f38ab1ba55f4
+        name: eu-west-3
+      - ami: ami-0774a6896e4ac35e0
+        name: eu-west-2
+      - ami: ami-032de7308a9eb91f5
+        name: eu-west-1
+      - ami: ami-08e8b1a5ad052751f
+        name: ap-northeast-3
+      - ami: ami-0fc6badc68b7b7dd1
+        name: ap-northeast-2
+      - ami: ami-06a5e5183080d4345
+        name: ap-northeast-1
+      - ami: ami-0f4797d1ea0ffbe21
+        name: sa-east-1
+      - ami: ami-0320e4ff5c5004a6b
+        name: ca-central-1
+      - ami: ami-041d6354bb257235d
+        name: ap-southeast-1
+      - ami: ami-0ef9fbc659adf4a7e
+        name: ap-southeast-2
+      - ami: ami-066eb78156cb8e30d
+        name: us-east-1
+      - ami: ami-08782642e97383550
+        name: us-east-2
+      - ami: ami-088a63ebb9b6d8cca
+        name: us-west-1
+      - ami: ami-0d3df510f088f6728
+        name: us-west-2
+      - ami: ami-0b8eda557039b448e
+        name: eu-central-1
+      version: 318.8.0
+    - regions:
       - ami: ami-0a7380651a94f34af
         name: eu-north-1
       - ami: ami-0f32041348763f71c
@@ -53,89 +89,45 @@ providerConfig:
         name: us-west-1
       - ami: ami-0d1ee9478903ca81f
         name: us-west-2
-      - ami: ami-af1d25ce
-        name: us-gov-west-1
-      - ami: ami-0e05a9dbe093f2152
-        name: us-gov-east-1
       version: 184.0.0
-    - regions:
-      - ami: ami-07ccc13d414bcef3c
-        name: ap-northeast-1
-      - ami: ami-0b2c6a4ec631bccf9
-        name: ap-northeast-2
-      - ami: ami-0ad05a1ae793d06fa
-        name: ap-south-1
-      - ami: ami-022ce9ff49b3ea2ab
-        name: ap-southeast-1
-      - ami: ami-034a6a56910b96871
-        name: ap-southeast-2
-      - ami: ami-0e4c5323dbb3e6935
-        name: ca-central-1
-      - ami: ami-04191efdc08e5aef6
-        name: eu-central-1
-      - ami: ami-0bb8dc8950bb9443c
-        name: eu-north-1
-      - ami: ami-0af0155fee34b4a4e
-        name: eu-west-1
-      - ami: ami-0d45e63a6e0e64049
-        name: eu-west-2
-      - ami: ami-04efa08d390e6c1b8
-        name: eu-west-3
-      - ami: ami-0973e4ec7b8cb9f4f
-        name: sa-east-1
-      - ami: ami-06ad56a1fb921d8f1
-        name: us-east-1
-      - ami: ami-0945b5300ed828e38
-        name: us-east-2
-      - ami: ami-09a83cb715f5b5637
-        name: us-west-1
-      - ami: ami-088e94e12398d7fce
-        name: us-west-2
-      version: 27.1.0
   - name: suse-chost
     versions:
     - regions:
-      - ami: ami-02579785f2b05157b
-        name: ap-northeast-1
-      - ami: ami-067508a84d7b6641f
-        name: ap-northeast-2
-      - ami: ami-069f3f4f56e924f63
-        name: ap-south-1
-      - ami: ami-0d4c14c79f6e310a5
-        name: ap-southeast-1
-      - ami: ami-0d74a68da62cc2ac3
-        name: ap-southeast-2
-      - ami: ami-0989317611619fef1
-        name: ca-central-1
-      - ami: ami-0c7126fabc4abaaa0
-        name: cn-north-1
-      - ami: ami-0a89bb145dc365f37
-        name: cn-northwest-1
-      - ami: ami-020aaee0bf8836bf0
-        name: eu-central-1
-      - ami: ami-07bf72646b6bf8b71
+      - ami: ami-0e8062501ac12dbdd
         name: eu-north-1
-      - ami: ami-03a23edcab5de0d24
-        name: eu-west-1
-      - ami: ami-028d904bdb398e5ca
-        name: eu-west-2
-      - ami: ami-07766d2fe3b6740bf
+      - ami: ami-0671a99072813baf2
+        name: ap-south-1
+      - ami: ami-0e0308c8101d7f36b
         name: eu-west-3
-      - ami: ami-0baf4819962cc32aa
+      - ami: ami-07c0a1b083fc3ffc0
+        name: eu-west-2
+      - ami: ami-0cae8a3a77df68846
+        name: eu-west-1
+      - ami: ami-02ffb4369087b4028
+        name: ap-northeast-3
+      - ami: ami-0870cae5572c5105d
+        name: ap-northeast-2
+      - ami: ami-007e785d4d6a7179b
+        name: ap-northeast-1
+      - ami: ami-0530c0f865aaeebe5
         name: sa-east-1
-      - ami: ami-04a20610a822532cf
+      - ami: ami-0aacb9d80505415b4
+        name: ca-central-1
+      - ami: ami-082c46d6f9c9ae133
+        name: ap-southeast-1
+      - ami: ami-04cdfdd8c04cb2314
+        name: ap-southeast-2
+      - ami: ami-0ec423476668d5d78
+        name: eu-central-1
+      - ami: ami-0ef7782793c55a691
         name: us-east-1
-      - ami: ami-0664f494d17a05314
+      - ami: ami-047e8e9eb9e2c1f82
         name: us-east-2
-      - ami: ami-0844897520bf0b0bf
-        name: us-gov-east-1
-      - ami: ami-bd350adc
-        name: us-gov-west-1
-      - ami: ami-023976e01bf1f5eb7
+      - ami: ami-0ab716bd991c0a905
         name: us-west-1
-      - ami: ami-07174570cb87e95c5
+      - ami: ami-0d5ec825ae5166bc2
         name: us-west-2
-      version: 15.1.20200615
+      version: 15.2.20210610
   - name: ubuntu
     versions:
     - regions:

--- a/components/gardencontent/profiles/provider/azure/iaas.yaml
+++ b/components/gardencontent/profiles/provider/azure/iaas.yaml
@@ -169,16 +169,18 @@ providerConfig:
   kind: CloudProfileConfig
   countFaultDomains:
     - count: 2
+      region: australiacentral
+    - count: 2
       region: australiaeast
     - count: 2
       region: australiasoutheast
-    - count: 2
+    - count: 3
       region: brazilsouth
     - count: 3
       region: canadacentral
     - count: 2
       region: canadaeast
-    - count: 2
+    - count: 3
       region: centralindia
     - count: 3
       region: centralus
@@ -188,8 +190,10 @@ providerConfig:
       region: eastus
     - count: 3
       region: eastus2
-    - count: 2
+    - count: 3
       region: francecentral
+    - count: 2
+      region: germanywestcentral
     - count: 2
       region: japaneast
     - count: 2
@@ -210,6 +214,8 @@ providerConfig:
       region: southeastasia
     - count: 2
       region: southindia
+    - count: 2
+      region: uaenorth
     - count: 2
       region: uksouth
     - count: 2
@@ -222,9 +228,11 @@ providerConfig:
       region: westindia
     - count: 3
       region: westus
-    - count: 2
+    - count: 3
       region: westus2
   countUpdateDomains:
+    - count: 5
+      region: australiacentral
     - count: 5
       region: australiaeast
     - count: 5
@@ -248,6 +256,8 @@ providerConfig:
     - count: 5
       region: francecentral
     - count: 5
+      region: germanywestcentral
+    - count: 5
       region: japaneast
     - count: 5
       region: japanwest
@@ -267,6 +277,8 @@ providerConfig:
       region: southeastasia
     - count: 5
       region: southindia
+    - count: 5
+      region: uaenorth
     - count: 5
       region: uksouth
     - count: 5
@@ -284,10 +296,10 @@ providerConfig:
   machineImages:
   - name: gardenlinux
     versions:
+    - urn: sap:gardenlinux:greatest:318.8.0
+      version: 318.8.0
     - urn: sap:gardenlinux:greatest:184.0.0
       version: 184.0.0
-    - urn: sap:gardenlinux:greatest:27.1.0
-      version: 27.1.0
   - name: ubuntu
     versions:
     - acceleratedNetworking: true
@@ -296,8 +308,8 @@ providerConfig:
   - name: suse-chost
     versions:
     - acceleratedNetworking: true
-      urn: suse:sles-15-sp2-chost-byos:gen1:2020.10.16
-      version: 15.2.20201016
+      urn: suse:sles-15-sp2-chost-byos:gen1:2021.06.10
+      version: 15.2.20210610
   machineTypes:
     - acceleratedNetworking: true
       name: Standard_D4_v3
@@ -351,6 +363,31 @@ providerConfig:
       name: Standard_M128
 
 regions:
+  - name: australiacentral
+  - name: australiaeast
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: australiasoutheast
+  - name: brazilsouth
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: canadacentral
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: canadaeast
+  - name: centralindia
+  - name: centralus
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: eastasia
   - name: eastus
     zones:
     - name: "1"
@@ -361,22 +398,16 @@ regions:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: centralus
+  - labels:
+      seed.gardener.cloud/eu-access: "true"
+    name: francecentral
     zones:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: northeurope
-    zones:
-    - name: "1"
-    - name: "2"
-    - name: "3"
-  - name: westeurope
-    zones:
-    - name: "1"
-    - name: "2"
-    - name: "3"
-  - name: southeastasia
+  - labels:
+      seed.gardener.cloud/eu-access: "true"
+    name: germanywestcentral
     zones:
     - name: "1"
     - name: "2"
@@ -386,24 +417,48 @@ regions:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: westus2
+  - name: japanwest
+  - name: koreacentral
+  - name: koreasouth
+  - name: northcentralus
+  - labels:
+      seed.gardener.cloud/eu-access: "true"
+    name: northeurope
     zones:
     - name: "1"
     - name: "2"
     - name: "3"
+  - name: southafricanorth
+  - name: southcentralus
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: southeastasia
+    zones:
+    - name: "1"
+    - name: "2"
+    - name: "3"
+  - name: southindia
+  - name: uaenorth
   - name: uksouth
     zones:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: FranceCentral
+  - name: ukwest
+  - name: westcentralus
+  - labels:
+      seed.gardener.cloud/eu-access: "true"
+    name: westeurope
     zones:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: EastUS2EUAP
+  - name: westindia
+  - name: westus
+  - name: westus2
     zones:
     - name: "1"
     - name: "2"
     - name: "3"
-  - name: uaenorth

--- a/components/gardencontent/profiles/provider/gcp/iaas.yaml
+++ b/components/gardencontent/profiles/provider/gcp/iaas.yaml
@@ -25,18 +25,18 @@ providerConfig:
   machineImages:
   - name: gardenlinux
     versions:
+    - image: projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-cloud-gardener--prod-318-8-ae20c2
+      version: 318.8.0
     - image: projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-cloud-gardener--prod-184-0-e5a157
       version: 184.0.0
-    - image: projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-cloud-gardener--prod-27-1-0
-      version: 27.1.0
   - name: ubuntu
     versions:
     - image: projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200218
       version: 18.4.20200228
   - name: suse-chost
     versions:
-    - image: projects/suse-byos-cloud/global/images/sles-15-sp2-chost-byos-v20201016
-      version: 15.2.20201016
+    - image: projects/suse-byos-cloud/global/images/sles-15-sp2-chost-byos-v20210610
+      version: 15.2.20210610
 
 machineTypes:
   - cpu: "2"

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.12.0"
+          "version": "v1.13.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.13.0"
+          "version": "v1.14.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.24.0"
+        "version": "v1.25.1"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.10.0"
+          "version": "v1.11.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.16.2"
+          "version": "v1.17.0"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.10.2"
+          "version": "v0.10.3"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
-          "version": "v0.8.0"
+          "version": "v0.9.0"
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.25.1"
+        "version": "v1.25.2"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.20.1"
+          "version": "v1.20.2"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.9.0"
+          "version": "v0.10.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -20,7 +20,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.10.0"
+          "version": "v1.11.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.25.2`
```
```feature operator
Update default kubernetes versions in cloudprofile
```
```feature operator
Update machine image versions in cloudprofile
```
```other operator
Upgrade Gardener extension provider-azure to `v1.20.2`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.13.0`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.14.0`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.17.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.10.0`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.10.3`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.11.0`
```
```other operator
Upgrade Gardener extension os-ubuntu to `v1.11.0`
```
```other operator
Upgrade Gardener extension os-gardenlinux to `v0.9.0`
```
