### PR TITLE
Upgrade Gardener, extensions, and default kubernetes versions

### DIFF
--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -51,19 +51,19 @@ defaults:
   kubernetes:
     versions:
       - classification: preview
-        version: 1.21.2
+        version: 1.21.3
       - classification: supported
+        version: 1.20.8
+      - classification: deprecated
         version: 1.20.6
-      - classification: deprecated
-        version: 1.20.4
       - classification: supported
+        version: 1.19.12
+      - classification: deprecated
         version: 1.19.10
-      - classification: deprecated
-        version: 1.19.8
       - classification: supported
-        version: 1.18.18
+        version: 1.18.20
       - classification: deprecated
-        version: 1.18.16
+        version: 1.18.18
       - classification: supported
         version: 1.17.17
       - version: 1.16.15

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -20,7 +20,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.11.0"
+          "version": "v1.13.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.14.0"
+          "version": "v1.17.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -68,7 +68,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.16.0"
+          "version": "v0.17.0"
         }
       }
     }

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.19.1"
+          "version": "v1.20.0"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.25.0"
+          "version": "v1.27.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.25.2"
+        "version": "v1.28.0"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.18.0"
+          "version": "v1.19.0"
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.11.0"
+          "version": "v1.12.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.20.2"
+          "version": "v1.21.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.13.0"
+          "version": "v1.14.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.10.3"
+          "version": "v0.10.4"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.28.0`
```
```feature operator
Update default kubernetes versions in cloudprofile
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.17.0`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.10.4`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.14.0`
```
```other operator
Upgrade Gardener terminal-controller-manager to `v0.17.0`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.12.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.19.0`
```
```other operator
Upgrade Gardener extension os-ubuntu to `v1.13.0`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.20.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.27.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.21.0`
```
