### PR TITLE
Update

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -32,6 +32,8 @@ ${ADD_DEPENDENCIES_CMD} \
     --component-dependencies \
     '{"name": "github.com/gardener/gardener-extension-provider-vsphere", "version": "'$(jq -r ".versions.gardener.extensions[\"provider-vsphere\"].version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
+    '{"name": "github.com/gardener/gardener-extension-runtime-gvisor", "version": "'$(jq -r ".versions.gardener.extensions[\"runtime-gvisor\"].version" <<< $DEP_VERSIONS)'"}' \
+    --component-dependencies \
     '{"name": "github.com/gardener/dashboard", "version": "'$(jq -r ".versions.dashboard.core.version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
     '{"name": "github.com/gardener/terminal-controller-manager", "version": "'$(jq -r ".versions.dashboard.terminals[\"terminal-controller-manager\"].version" <<< $DEP_VERSIONS)'"}' \

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -48,6 +48,8 @@ elif dep_name == 'github.com/gardener/gardener-extension-shoot-dns-service':
     set_dep_version(dep_version, 'versions', 'gardener', 'extensions', 'shoot-dns-service', 'version')
 elif dep_name == 'github.com/gardener/gardener-extension-provider-vsphere':
     set_dep_version(dep_version, 'versions', 'gardener', 'extensions', 'provider-vsphere', 'version')
+elif dep_name == 'github.com/gardener/gardener-extension-runtime-gvisor':
+    set_dep_version(dep_version, 'versions', 'gardener', 'extensions', 'runtime-gvisor', 'version')
 elif dep_name == 'github.com/gardener/dashboard':
     set_dep_version(dep_version, 'versions', 'dashboard', 'core', 'version')
 elif dep_name == 'github.com/gardener/terminal-controller-manager':

--- a/acre.yaml
+++ b/acre.yaml
@@ -144,6 +144,13 @@ landscape:
           chart_path: charts/gardener-extension-provider-vsphere
           image_tag: (( valid( provider-vsphere.tag ) ? provider-vsphere.tag :~~ ))
           image_repo: (( ~~ ))
+        runtime-gvisor:
+          <<: (( merge ))
+          tag: (( valid( runtime-gvisor.branch ) -or valid( runtime-gvisor.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.runtime-gvisor.version ))
+          repo: (( .dependency_versions.versions.gardener.extensions.runtime-gvisor.repo ))
+          chart_path: charts/gardener-extension-runtime-gvisor
+          image_tag: (( valid( runtime-gvisor.tag ) ? runtime-gvisor.tag :~~ ))
+          image_repo: (( ~~ ))
     dashboard:
       <<: (( merge ))
       repo: (( .dependency_versions.versions.dashboard.core.repo ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -58,7 +58,6 @@ dashboard:
     oidc:
       issuerUrl: (( imports.identity.export.issuer_url ))
       ca: (( imports.cert-controller.export.ca.crt || ~~ ))
-      redirectUri: (( imports.identity.export.callback_url ))
       clientSecret: (( imports.identity.export.dashboardClientSecret ))
       public:
         clientId: kube-kubectl

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -34,13 +34,30 @@ defaults:
       - name: gardenlinux
         versions:
         - version: 318.8.0
+          cri:
+          - name: docker
+          - containerRuntimes:
+            - type: gvisor
+            name: containerd
         - version: 184.0.0
+          cri:
+          - name: docker
+          - containerRuntimes:
+            - type: gvisor
+            name: containerd
       - name: ubuntu
         versions:
         - version: 18.4.20200228
+          cri:
+          - name: docker
+          - containerRuntimes:
+            - type: gvisor
+            name: containerd
       - name: suse-chost
         versions:
         - version: 15.2.20210610
+          cri:
+          - name: docker
     machineTypes:
       - <<: (( defaults.providerspec.machineTypes || ~ ))
     volumeTypes:

--- a/components/gardencontent/profiles/manifests/manifest.yaml
+++ b/components/gardencontent/profiles/manifests/manifest.yaml
@@ -67,16 +67,16 @@ defaults:
     caBundle: (( values.config.caBundle || ~~ ))
   kubernetes:
     versions:
-      - classification: preview
+      - classification: supported
         version: 1.21.3
       - classification: supported
+        version: 1.20.9
+      - classification: deprecated
         version: 1.20.8
-      - classification: deprecated
-        version: 1.20.6
       - classification: supported
-        version: 1.19.12
+        version: 1.19.13
       - classification: deprecated
-        version: 1.19.10
+        version: 1.19.12
       - classification: supported
         version: 1.18.20
       - classification: deprecated

--- a/components/gardencontent/profiles/provider/gcp/iaas.yaml
+++ b/components/gardencontent/profiles/provider/gcp/iaas.yaml
@@ -14,10 +14,7 @@
 
 <<: (( &template ))
 
-machineImages:
-  - name: gardenlinux
-    versions:
-    - version: 27.1.0
+machineImages: {}
 
 providerConfig:
   apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -37,6 +37,7 @@ default_extensions:
   - os-gardenlinux
   - dns-external
   - networking-calico
+  - runtime-gvisor
   - <<: (( sum[.infrastructures|[]|s,e|-> s [ "provider-" e ]] ))
   - (( ( .landscape.dashboard.terminals.active || false ) ? "shoot-cert-service" :~~ ))
 activated_extensions: (( valid( landscape.gardener.extensions ) ? keys(select{landscape.gardener.extensions|e|-> valid( e.active ) -and ( e.active == true )}) :[] ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -64,6 +64,7 @@ manifest_templates:
       deployment:
         deploymentRefs:
         - name: (( data.extensionName ))
+        policy: OnDemand
       resources: (( data.resources ))
 
 
@@ -430,4 +431,30 @@ extension_specs:
     - kind: Extension
       type: shoot-dns-service
       globallyEnabled: true
+      primary: true
+
+########################################
+  runtime-gvisor:
+########################################
+    <<: (( &template ))
+    extensionName: runtime-gvisor
+    type: helm
+    providerConfig:
+      chart: (( encoded_chart ))
+      values:
+        <<: (( valuesOverwrite ))
+        concurrentSyncs: 25
+        image:
+          repository: (( version.image_repo || ~~ ))
+          tag: (( version.image_tag || ~~ ))
+        resources:
+          limits:
+            cpu: 300m
+            memory: 700Mi
+          requests:
+            cpu: 30m
+            memory: 256Mi
+    resources:
+    - kind: ContainerRuntime
+      type: gvisor
       primary: true

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.17.0"
+          "version": "v1.18.0"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -59,7 +59,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.50.2"
+        "version": "1.51.2"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.17.0"
+          "version": "v1.17.1"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -53,6 +53,10 @@
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
           "version": "v0.10.0"
+        },
+        "runtime-gvisor": {
+          "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
+          "version": "v0.2.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
-          "version": "v0.9.0"
+          "version": "v0.10.0"
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.12.0"
+          "version": "v1.13.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.21.0"
+          "version": "v1.21.2"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.28.0"
+        "version": "v1.29.0"
       },
       "extensions": {
         "dns-external": {


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.29.0`
```
```feature operator
In preparation of the kubernetes dockershim removal, `containerd` has been added as container runtime to the default cloudprofiles. See [here](https://github.com/gardener/gardener/blob/release-v1.29/docs/usage/docker-shim-removal.md) for further information.
  - In addition, the `gvisor` extension is now deployed by default and can be used in combination with containerd.
```
```feature operator
Update default kubernetes versions in cloudprofile
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.18.0`
```
```other operator
Upgrade Gardener extension os-gardenlinux to `v0.10.0`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.13.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.21.2`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.17.1`
```
```feature operator
Upgrade Gardener dashboard  to `v1.51.2`
```
