### PR TITLE
Reintroduce CoreOS as a non-default extension

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -67,6 +67,13 @@ landscape:
           image_repo: (( ~~ ))
           repo: (( .dependency_versions.versions.gardener.extensions.dns-external.repo ))
           chart_path: charts/external-dns-management
+        os-coreos:
+          <<: (( merge ))
+          tag: (( valid( os-coreos.branch ) -or valid( os-coreos.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-coreos.version ))
+          repo: (( .dependency_versions.versions.gardener.extensions.os-coreos.repo ))
+          chart_path: charts/gardener-extension-os-coreos
+          image_tag: (( valid( os-coreos.tag ) ? os-coreos.tag :~~ ))
+          image_repo: (( ~~ ))
         os-ubuntu:
           <<: (( merge ))
           tag: (( valid( os-ubuntu.branch ) -or valid( os-ubuntu.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-ubuntu.version ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -72,6 +72,32 @@ extension_specs:
   <<: (( &temporary ))
 
 ########################################
+  os-coreos:
+########################################
+    <<: (( &template ))
+    extensionName: os-coreos
+    type: helm
+    providerConfig:
+      chart: (( encoded_chart ))
+      values:
+        <<: (( valuesOverwrite ))
+        concurrentSyncs: 25
+        image:
+          repository: (( version.image_repo || ~~ ))
+          tag: (( version.image_tag || ~~ ))
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+    resources:
+      - kind: OperatingSystemConfig
+        type: coreos
+        primary: true
+
+########################################
   os-ubuntu:
 ########################################
     <<: (( &template ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -14,6 +14,10 @@
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
           "version": "v1.19.1"
         },
+        "os-coreos": {
+          "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",
+          "version": "v1.8.0"
+        },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
           "version": "v1.13.0"

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -22,12 +22,13 @@ While garden-setup automatically decides which Gardener extensions to deploy, it
 Whatever is specified in `landscape.gardener.extensions.<extensionName>.valueOverwrites` will be given directly to the helm values for the extension, so you can overwrite the corresponding default values. 
 Some values are set by default (take a look in the [deployment.yaml](../../components/gardener/extensions/deployment.yaml)), this values can also overwrite with the `landscape.gardener.extensions.<extensionName>.valueOverwrites`.
 
-The following extensions are availibe in `landscape.gardener.extensions`:
+The following extensions are available in `landscape.gardener.extensions`:
 
 - dns-external: [values.yaml](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/charts/gardener-extension-shoot-dns-service/values.yaml)
 - os-ubuntu: [values.yaml](https://github.com/gardener/gardener-extension-os-ubuntu/blob/master/charts/gardener-extension-os-ubuntu/values.yaml)
 - os-gardenlinux: [values.yaml](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/master/charts/gardener-extension-os-gardenlinux/values.yaml)
 - os-suse-chost: [values.yaml](https://github.com/gardener/gardener-extension-os-suse-chost/blob/master/charts/gardener-extension-os-suse-chost/values.yaml)
+- os-coreos: [values.yaml](https://github.com/gardener/gardener-extension-os-coreos/blob/master/charts/gardener-extension-os-coreos/values.yaml)
 - provider-aws: [values.yaml](https://github.com/gardener/gardener-extension-provider-aws/blob/master/charts/gardener-extension-provider-aws/values.yaml)
 - provider-gcp: [values.yaml](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/charts/gardener-extension-provider-gcp/values.yaml)
 - provider-azure: [values.yaml](https://github.com/gardener/gardener-extension-provider-azure/blob/master/charts/gardener-extension-provider-azure/values.yaml)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reintroduces the CoreOS extension as discussed with @einfachnuralex

**Which issue(s) this PR fixes**:

Removing the extension prevented us from using up-to-date Flatcar Linux images

**Special notes for your reviewer**:
-

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Reintroduce CoreOS as a non-default extension
```
