### PR TITLE
Add remote_write feature configuration

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -249,6 +249,8 @@ landscape:
     password: (( ~~ ))
     hash: (( ~~ ))
     customScrapeConfigPath: (( ~~ ))
+    remoteWrite: (( ~~ ))
+    externalLabels: (( ~~ ))
   cert-manager:
     <<: (( merge ))
     server: (( merge none // valid( stub() ) ? ( type( stub() ) == "map" ? stub() :{ "url" = stub() } ) :{"url" = "self-signed"} ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -59,7 +59,18 @@ secretManifests:
   type: Opaque
   data:
     <<: (( sum[configValues.dns.credentials|{}|ss,sk,sv|-> ss { sk = base64(sv) }] ))
-
+- <<: (( defined(configValues.monitoring.remoteWrite) ? ~ :~~ ))
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "monitoring-seed-remote-write-credentials"
+    namespace: "garden"
+    labels:
+      gardener.cloud/role: global-shoot-remote-write-monitoring
+  type: Opaque
+  data:
+    username: (( base64(configValues.monitoring.remoteWrite.username) ))
+    password: (( base64(configValues.monitoring.remoteWrite.password) ))
 seedSpec:
   <<: (( &temporary ))
   provider:
@@ -226,10 +237,21 @@ gardenletSpec:
           metadata:
             name: (( configValues.name ))
           spec: (( seedSpec ))
+        monitoring: (( defined(configValues.monitoring.remoteWrite) ? monitoringTemplate :~~ ))
     # Deployment related configuration
     deployment:
       virtualGarden:
         enabled: true
+
+monitoringTemplate:
+  <<: (( &temporary ))
+  shoot:
+    remoteWrite:
+      url: (( configValues.monitoring.remoteWrite.url || ~~ ))
+      keep: (( configValues.monitoring.remoteWrite.keep || ~~ ))
+      queueConfig: (( configValues.monitoring.remoteWrite.queueConfig || ~~ ))
+    externalLabels:
+      <<: (( configValues.monitoring.externalLabels || {} ))
 
 pluginSpecs:
   managedIstioActive: (( configValues.config.featureGates.ManagedIstio || false ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -76,5 +76,6 @@ providerconfig:
     shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
     settings: (( v.seedSettings || ~~ ))
   secretname: (( name "-" v.mode ))
+  monitoring: (( landscape.monitoring ))
 
 renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/components/monitoring/prometheus/deployment.yaml
+++ b/components/monitoring/prometheus/deployment.yaml
@@ -20,7 +20,6 @@ settings:
   monitoring_credentials: (( .state.monitoring_credentials.value ))
   prometheus_domain: (( "garden-prometheus." .imports.ingress-controller.export.ingress_domain ))
   monitoring: (( landscape.monitoring ))
-
 monitoring_password:
   <<: (( &temporary ))
   input:

--- a/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
+++ b/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
@@ -18,10 +18,19 @@ templates:
   default_scrape_configs: (( templates.parse_scrape_configs( __ctx.DIR "/manifests/scrape-configs" ) ))
   custom_scrape_configs: (( defined(templates.custom_path) ? templates.parse_scrape_configs( templates.custom_path ) :[] ))
 
+  remote_write:
+  - url: (( values.settings.monitoring.remoteWrite.url || ~~ ))
+    basic_auth:
+      username: (( values.settings.monitoring.remoteWrite.username || ~~ ))
+      password: (( values.settings.monitoring.remoteWrite.password || ~~ ))
+
   config_data:
     global:
       evaluation_interval: 30s
       scrape_interval: 30s
+      external_labels:
+        <<: (( values.settings.monitoring.externalLabels || ~~ ))
+    remote_write: (( defined(values.settings.monitoring.remoteWrite) ? templates.remote_write :~~ ))
 
     rule_files:
     - /etc/prometheus/rules/*.yaml

--- a/docs/extended/monitoring.md
+++ b/docs/extended/monitoring.md
@@ -17,3 +17,27 @@ Via the `landscape.monitoring` node, the monitoring feature can be activated. If
 - `monitoring.customScrapeConfigPath`: if set, all `yaml` files in this folder will be added to the prometheus `scrape_config`. Preceding `./` can be omitted. Absolute aswell as relative paths like `../configs` work.
 
 Instead of username and password, `monitoring.hash` can be specified, containing a hash of the password. The hash should be created via `htpasswd -nb <username> <password>`.
+
+## Configure Prometheus `remote_write`
+
+You can also configure Prometheus to use the `remote_write` feature for central logging. See the 
+following configuration:
+
+```yaml
+landscape:
+  ...
+  monitoring:
+    ... # (see above)
+    remoteWrite:
+      url: # url path to remote_write endpoint
+      username: # remote_write username
+      password: # remote_write password
+    externalLabels:
+      key1: value1
+      key2: value2
+      ...
+```
+
+You can set credentials for the remote_write endpoint reachable at `url` using `username` and
+`password`. The optional user-defined key-value pairs underneath `externalLabels` are passed to
+the Prometheus _external labels_ config option.


### PR DESCRIPTION
**What this PR does / why we need it**:

@dergeberl introduced the remote_write feature to gardener in https://github.com/gardener/gardener/pull/4935 

This PR adds configuration options to enable this feature in garden-setup.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add remote_write prometheus configuration option
```
