### PR TITLE
Enhance resource limits and requests configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ landscape:
       resourceGroup:                          # Azure resource group you would like to use for your backup
       region: (( iaas.region ))               # region of blob storage (default: same as above)
       credentials: (( iaas.credentials ))     # credentials for the blob storage's IaaS provider (default: same as above)
+    resources:                                # optional: override resource requests and limits defaults
+      requests:
+        cpu: 400m
+        memory: 2000Mi
+      limits:
+        cpu: 1
+        memory: 2560Mi
 
   <a href="#landscapedns">dns</a>:                                    # optional for gcp/aws/azure/openstack, default values based on `landscape.iaas`
     type: &lt;google-clouddns|aws-route53|azure-dns|openstack-designate|cloudflare-dns|infoblox-dns&gt;   # dns provider

--- a/acre.yaml
+++ b/acre.yaml
@@ -704,6 +704,10 @@ validation:
             - - optionalfield
               - privateKey
               - privatekey
+          - - optionalfield
+    - - optionalfield
+      - resources
+      - (( validation.resources_validator ))
   dashboard_no_seed_strategy_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
   dashboard_terminals_validator: (( |db,cm|-> [! (( db.terminals.active || false ) -and ( cm.server.url == "self-signed" -or cm.server.url == "staging" )), "valid", "the 'dashboard terminals' feature requires trusted certificates, please configure the cert-manager accordingly"] ))
   networks:
@@ -760,6 +764,17 @@ validation:
     - ["optionalfield", "allowProjectCreationForAll", ["type", "bool"]]
     - ["optionalfield", "useIdentityDomain", ["type", "bool"]]
 
+  resources_validator:                      # resource nodes are
+    - map                                   # maps that contain
+    - ["valueset", ["limits", "requests"]]  # the keys 'limits' or 'requests' only,
+    - - map                                 # which in turn contain a map
+      - - or                                # with the following keys:
+        - ["valueset", ["cpu", "memory"]]   # 'cpu' or 'memory' exactly, or
+        - ["match", "^hugepages-"]          # a key starting with 'hugepages-'.
+      - - or                                # these maps either contain
+        - ["type", "int"]                   # integers or
+        - ["type", "string"]                # strings
+
 
   ### VALIDATIONS ###
   # structure resembles structure of landscape where possible
@@ -779,6 +794,7 @@ validation:
     shooted_seed: (( map[validation.flatten( select[select[landscape.iaas|elem|-> elem.mode == "seed" -or elem.mode == "soil"]|elem|-> valid( elem.seeds )].[*].seeds ) |entry|-> validate( entry, validation.instantiate_validator(entry, iaas_entry_validators.basic), validation.instantiate_validator(entry, iaas_entry_validators.shooted_seed) )] ))
   ##### landscape.etcd
   etcd:
+    resources: (( defined( landscape.etcd.resources ) ? validate( landscape.etcd.resources, validation.resources_validator ) :~~ ))
     backup_active: (( validate( landscape.etcd.backup.active, ["type", "bool"] ) ))
     backup: (( landscape.etcd.backup.active == true ? validate( landscape.etcd.backup, [ "and", validation.instantiate_validator( landscape.etcd.backup, validation.types.backup_config ), validation.types.etcd_backup[landscape.etcd.backup.type].config ] ) :~~ ))
   ##### landscape.dns
@@ -789,6 +805,11 @@ validation:
     credentials: (( validate( landscape.dns, ["mapfield", "credentials", types.dns[landscape.dns.type].credentials] ) ))
   ##### landscape.gardener
   gardener:
+    resources:
+      apiserver: (( defined( landscape.gardener.resources.apiserver ) ? validate( landscape.gardener.resources.apiserver, validation.resources_validator ) :~~ ))
+      admission: (( defined( landscape.gardener.resources.admission ) ? validate( landscape.gardener.resources.admission, validation.resources_validator ) :~~ ))
+      controller: (( defined( landscape.gardener.resources.controller ) ? validate( landscape.gardener.resources.controller, validation.resources_validator ) :~~ ))
+      scheduler: (( defined( landscape.gardener.resources.scheduler ) ? validate( landscape.gardener.resources.scheduler, validation.resources_validator ) :~~ ))
     seedCandidateDeterminationStrategy: (( defined( landscape.gardener.seedCandidateDeterminationStrategy ) ? validate( landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]] ) :~~ ))
     network-policies: (( defined( landscape.gardener.network-policies ) ? validate( landscape.gardener.network-policies, ["optionalfield", "active", ["type", "bool"]] ) :~~ ))
     extensions: (( defined( landscape.gardener.extensions ) ? validate( keys( landscape.gardener.extensions ), ["list", ["valueset", keys( landscape.versions.gardener.extensions )]] ) :~~ ))

--- a/acre.yaml
+++ b/acre.yaml
@@ -704,7 +704,6 @@ validation:
             - - optionalfield
               - privateKey
               - privatekey
-          - - optionalfield
     - - optionalfield
       - resources
       - (( validation.resources_validator ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -79,6 +79,8 @@ dashboard:
         <<: (( .landscape.dashboard.frontendConfig.features || ~ ))
         terminalEnabled: (( ( .landscape.dashboard.terminals.active || false ) ))
     terminal: (( ( .landscape.dashboard.terminals.active || false ) ? *.terminal_config :~~ ))
+    resources:
+      <<: (( .landscape.dashboard.resources || ~~ ))
 
 terminal_config:
   <<: (( &temporary &template ))

--- a/components/etcd/cluster/chart/templates/statefulset-etcd.yaml
+++ b/components/etcd/cluster/chart/templates/statefulset-etcd.yaml
@@ -81,11 +81,11 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{ .Values.resources.requests.cpu | default "400m" }}
+            memory: {{ .Values.resources.requests.memory | default "2000Mi" }}
           limits:
-            cpu: 750m
-            memory: 2560Mi
+            cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
+            memory: {{ .Values.resources.limits.memory | default "2560Mi" }}
         volumeMounts:
         - name: {{ .Values.name }}
           mountPath: /var/etcd/data

--- a/components/etcd/cluster/chart/values.yaml
+++ b/components/etcd/cluster/chart/values.yaml
@@ -38,6 +38,14 @@ tls:
     crt: client-certificate
     key: client-key
 
+resources:
+  requests:
+    cpu: 400m
+    memory: 2000Mi
+  limits:
+    cpu: 1000m
+    memory: 2560Mi
+
 # Aws S3 storage configuration
 # Note: No volumeMounts variable needed
 # storageProvider: "S3"

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -108,6 +108,8 @@ etcd:
           crt: (( state.client.value.cert ))
           key: (( state.client.value.key ))
 
+      resources:
+        <<: (( landscape.etcd.resources || ~~ ))
   events:
     kubeconfig: (( landscape.clusters.[0].kubeconfig ))
     files:

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -117,11 +117,11 @@ default_resources:
       memory: 100Mi
   scheduler:
     limits:
-      cpu: (( ~~ ))
-      memory: (( ~~ ))
+      cpu: 300m
+      memory: 256Mi
     requests:
-      cpu: (( ~~ ))
-      memory: (( ~~ ))
+      cpu: 50m
+      memory: 50Mi
 
 gardener:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -2,8 +2,11 @@
 
 The `landscape.dashboard` node is entirely optional. 
 Whatever is specified for
+
 - `landscape.dashboard.frontendConfig`
 - `landscape.dashboard.gitHub`
+- `landscape.dashboard.resources`
+
 will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values.
 
 Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).
@@ -54,4 +57,25 @@ The terminals need trusted certificates and won't work with self-signed ones. Th
 
 Due to technical limitations, some ingresses in shoot will have a `cert-manager.io/cluster-issuer: ...` annotation despite the cert-manager not being deployed on the shoots. To avoid conflicts when valid certificates are needed on a shoot, you can either use the [shoot-cert-service](https://github.com/gardener/gardener-extensions/tree/master/controllers/extension-shoot-cert-service), which is deployed on the shoot, or, if you want to use your own cert-manager deployment, make sure you choose a different name for your clusterissuer(s).
 
-Check out the [terminal-controller-manager](https://github.com/gardener/terminal-controller-manager) for more information on the terminals.
+Check out the
+[terminal-controller-manager](https://github.com/gardener/terminal-controller-manager)
+for more information on the terminals.
+
+### landscape.dashboard.resources
+
+With the optional `resources` field, you can override the default limits and requests for the dashboard.
+
+```yaml
+  ...
+  dashboard:
+    ...
+    resources:
+      requests:
+        cpu: 400m
+        memory: 2000Mi
+      limits:
+        cpu: 800m
+        memory: 2560Mi
+```
+
+This field expects the values in the standard Kubernetes format for resource requests and limits. Refer to the [Kubernetes docs for container resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.


### PR DESCRIPTION
**What this PR does / why we need it**:

A year ago, https://github.com/gardener/garden-setup/pull/345 made gardener resource limits and requests configurable in garden-setup. This PR improves and enhances the feature in the following areas:

* The resource fields set by the user are now validated with a relatively strict validator, see [the acre.yaml file](https://github.com/gardener/garden-setup/compare/master...SimonKienzler:feature/resource-limits?expand=1#diff-a179d9910ae6a1b59d61758192dfb37f7d66453f7b71bb0384a9b5d1a5a390c5R767) -- this could be relaxed with a more forgiving validator if wanted.
* Now, you can also add limits/requests for the `dashboard` and the `etcd` components.
* Defaults are kept if nothing is set in acre.yaml.

**Which issue(s) this PR fixes**:

* The limits and requests of the `gardener-scheduler` were not deployed because of the `(( ~~ ))` default config, I added the standard limits/requests values from the deployment.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Resource requests and limits can now be configured for scheduler, dashboard, and ectd, too.
```
