### PR TITLE
Make gardenlet logging configurable

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -214,6 +214,8 @@ gardenletSpec:
           retryPeriod: 2s
           resourceLock: configmaps
         logLevel: info
+        logging:
+          <<: (( configValues.config.logging || ~~ ))
         kubernetesLogLevel: 0
         featureGates: 
           <<: (( configValues.config.featureGates || {} ))

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -42,6 +42,11 @@ iaas:
         enabled: true
       verticalPodAutoscaler:
         enabled: true
+    logging:                                     # optional, configure logging settings for the gardenlet
+    # fluentBit:                                 # example for FluentBit
+    #   output: |-
+    #     [Output]
+    #         ...
       ...
   - name:                                        # see above
     mode: <seed|cloudprofile|profile|inactive>   # what should be deployed


### PR DESCRIPTION
**What this PR does / why we need it**:

The gardenlet `logging` configuration can be set via `acre.yaml` once this PR is merged. Very small change but helps us a lot!

Already added documentation :)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Make gardenlet logging configurable
```
