### PR TITLE
Allow adding custom scrape_configs for prometheus

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -248,6 +248,7 @@ landscape:
     username: admin
     password: (( ~~ ))
     hash: (( ~~ ))
+    customScrapeConfigPath: (( ~~ ))
   cert-manager:
     <<: (( merge ))
     server: (( merge none // valid( stub() ) ? ( type( stub() ) == "map" ? stub() :{ "url" = stub() } ) :{"url" = "self-signed"} ))

--- a/components/monitoring/prometheus/deployment.yaml
+++ b/components/monitoring/prometheus/deployment.yaml
@@ -19,6 +19,7 @@ kubectlconfig:
 settings:
   monitoring_credentials: (( .state.monitoring_credentials.value ))
   prometheus_domain: (( "garden-prometheus." .imports.ingress-controller.export.ingress_domain ))
+  monitoring: (( landscape.monitoring ))
 
 monitoring_password:
   <<: (( &temporary ))

--- a/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
+++ b/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
@@ -8,38 +8,45 @@ metadata:
     role: prometheus
     context: garden
 data:
-  config.yaml: (( asyaml( config_data ) ))
+  config.yaml: (( asyaml( templates.config_data ) ))
 
+templates:
+  <<: (( &temporary ))
 
-config_data:
-  <<: (( &temporary ))    
-  global:
-    evaluation_interval: 30s
-    scrape_interval: 30s
+  custom_path: (( values.settings.monitoring.customScrapeConfigPath || ~~ )) # to improve readability
+  parse_scrape_configs: (( lambda |folder|-> sum[list_files( folder )|[]|scrape,file|-> scrape read( folder "/" file )] ))
+  default_scrape_configs: (( templates.parse_scrape_configs( __ctx.DIR "/manifests/scrape-configs" ) ))
+  custom_scrape_configs: (( defined(templates.custom_path) ? templates.parse_scrape_configs( templates.custom_path ) :[] ))
 
-  rule_files:
-  - /etc/prometheus/rules/*.yaml
+  config_data:
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
 
-  alerting:
-    alertmanagers:
-    - kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - garden
-      scheme: http
-      relabel_configs:
-      - source_labels: [ __meta_kubernetes_service_label_context ]
-        action: keep
-        regex: garden
-      - source_labels: [ __meta_kubernetes_service_label_app ]
-        action: keep
-        regex: monitoring
-      - source_labels: [ __meta_kubernetes_service_label_role ]
-        action: keep
-        regex: alertmanager
-      - source_labels: [ __meta_kubernetes_endpoint_port_name ]
-        action: keep
-        regex: web
+    rule_files:
+    - /etc/prometheus/rules/*.yaml
 
-  scrape_configs: (( sum[list_files( __ctx.DIR "/manifests/scrape-configs" )|[]|scrape,sconf|-> scrape read( __ctx.DIR "/manifests/scrape-configs/" sconf )] ))
+    alerting:
+      alertmanagers:
+      - kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+            - garden
+        scheme: http
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_service_label_context ]
+          action: keep
+          regex: garden
+        - source_labels: [ __meta_kubernetes_service_label_app ]
+          action: keep
+          regex: monitoring
+        - source_labels: [ __meta_kubernetes_service_label_role ]
+          action: keep
+          regex: alertmanager
+        - source_labels: [ __meta_kubernetes_endpoint_port_name ]
+          action: keep
+          regex: web
+
+    scrape_configs: (( [templates.default_scrape_configs..., templates.custom_scrape_configs...] ))
+

--- a/docs/extended/monitoring.md
+++ b/docs/extended/monitoring.md
@@ -7,11 +7,13 @@ landscape:
     active: false
     username: admin
     password: # password in clear-text
+    customScrapeConfigPath: ./my-scrape-configs
 ```
 
 Via the `landscape.monitoring` node, the monitoring feature can be activated. If activated, garden-setup will deploy a [Prometheus](https://prometheus.io/) and a [Grafana](https://grafana.com/) instance in the cluster, as well as the [Gardener Metrics Exporter](https://github.com/gardener/gardener-metrics-exporter). The monitoring is pre-configured and can not be adapted in the `acre.yaml` currently.
 - `monitoring.active`: if set to `true` (or anything else that is recognized as `true` by YAML), the monitoring components will be deployed. Defaults to `false`.
 - `monitoring.username`: the username for the ingress authentication to access the monitoring dashboards. Defaults to `admin`.
 - `monitoring.password`: the clear-text password for the ingress authentication to access the monitoring dashboards. Will be automatically generated and stored in the state (clear-text and hash) and export (hash only) of the `monitoring/prometheus` component, if not given.
+- `monitoring.customScrapeConfigPath`: if set, all `yaml` files in this folder will be added to the prometheus `scrape_config`. Preceding `./` can be omitted. Absolute aswell as relative paths like `../configs` work.
 
 Instead of username and password, `monitoring.hash` can be specified, containing a hash of the password. The hash should be created via `htpasswd -nb <username> <password>`.


### PR DESCRIPTION
**What this PR does / why we need it**:  
This feature allows specifying a folder that contains none or multiple Prometheus `scrape_configs` which are dynamically added to the Prometheus `scrape_config`.

**Release note**:
```feature operator
Allows adding custom scrape_config files for Prometheus
```
