### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.29.0"
+          "version": "v1.30.1"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "dns-external": {
           "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.10.7"
+          "version": "v0.11.2"
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -12,7 +12,7 @@
         },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.19.1"
+          "version": "v1.21.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.33.1"
+        "version": "v1.36.0"
       },
       "extensions": {
         "dns-external": {


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.36.0`
```
```other operator
Upgrade Gardener dns-controller-manager to `v0.11.2`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.30.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.21.0`
```
