### PR TITLE
migrate ingress resources to networking.k8s.io/v1

### DIFF
--- a/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
+++ b/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -26,8 +26,11 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .Values.serviceName }}
-          servicePort: 443
+          service:
+            name: {{ .Values.serviceName }}
+            port:
+              number: 443
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - {{ .Values.apiServer.hostname }}

--- a/components/monitoring/grafana/manifests/60-ingress.yaml
+++ b/components/monitoring/grafana/manifests/60-ingress.yaml
@@ -12,7 +12,7 @@ data:
   auth: (( base64( .imports.prometheus.export.monitoring_auth ) ))
 type: Opaque
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: garden-grafana
@@ -32,9 +32,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: garden-grafana
-          servicePort: 80
+          service:
+            name: garden-grafana
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - (( .settings.grafana_domain ))

--- a/components/monitoring/prometheus/manifests/50-ingress.yaml
+++ b/components/monitoring/prometheus/manifests/50-ingress.yaml
@@ -12,7 +12,7 @@ data:
   auth: (( base64( values.settings.monitoring_credentials.hash ) ))
 type: Opaque
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: garden-prometheus
@@ -32,9 +32,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: garden-prometheus
-          servicePort: 80
+          service:
+            name: garden-prometheus
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - (( values.settings.prometheus_domain ))


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ingress manifests have been migrated to `networking.k8s.io/v1`.
```
