### PR TITLE
add template for dashboard ingress annotations

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -51,6 +51,8 @@ dashboard:
       hosts:
         - (( imports.identity.export.dashboard_dns ))
         - (( .landscape.dashboard.cname.domain || ~~ ))
+      annotations:
+        <<: (( .landscape.dashboard.ingress.annotations || ~~ ))
     image:
       repository: (( .dashboard_version.image_repo || ~~ ))
       tag: (( .dashboard_version.image_tag || ~~ ))

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -12,6 +12,22 @@ will be given directly to the [dashboard helm chart](https://github.com/gardener
 Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).
 The same is true for `frontendConfig.features.terminalEnabled`. See [below](#landscape-dashboard-terminals) on how to activate the terminals.
 
+### landscape.dashboard.ingress.annotations
+
+Via `landscape.dashboard.ingress.annotations`, an additional list of annotations can be set on the dashboard ingress.
+
+For example, when using the `nginx ingress controller` you may specify an annotation like below to alter its configuration:
+
+```yaml
+  ...
+  dashboard:
+    ...
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/24"
+        ...
+```
+
 ### landscape.dashboard.cname
 
 With `landscape.dashboard.cname`, you can provide another domain from which the dashboard will be reachable.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an additional (optional) field to the dashboard deployment, adding support for additional ingress annotations.
With this, all annotations specified in `landscape.dashboard.ingress.annotations` will be added to the resulting dashboard `Ingress` resource.

**Which issue(s) this PR fixes**:

We've stumbled across an issue using the `nginx` ingress controller in combination with `dex` as the oAuth provider, requiring us to set custom annotations on the dashboard's `Ingress`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add dashboard ingress annotation option
```
