### PR TITLE
Add ectd maxBackups and schedule as optional configurable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ etcd:
     resourceGroup: ...
     region: (( iaas.region ))
     credentials: (( iaas.credentials ))
+    # schedule: "0 */24 * * *"          # optional, default: 24h
+    # maxBackups: 7                     # optional, default: 7
 ```
 Configuration of what blob storage to use for the etcd key-value store. If your IaaS provider offers a blob storage you can use the same values for `etc.backup.region` and `etc.backup.credentials` as above for `iaas.region` and `iaas.credentials` correspondingly by using the [(( foo ))](https://github.com/mandelsoft/spiff/blob/master/README.md#-foo-) expression of spiff.
 If the type of `landscape.iaas[0]` is one of `gcp`, `aws`, `azure`, or `openstack`, this block can be defaulted - either partly or as a whole - based on values from `landscape.iaas`. The `resourceGroup`, which is necessary for Azure, cannot be defaulted and must be specified. Make sure that the specified `resourceGroup` is empty and unused as deleting the cluster using `sow delete all` deletes this `resourceGroup`.

--- a/acre.yaml
+++ b/acre.yaml
@@ -488,6 +488,8 @@ validation:
         - - valueset
           - (( keys( types.etcd_backup ) ))
       - ["mapfield", "region"]
+      - ["optionalfield", "schedule", ["type", "string"]]
+      - ["optionalfield", "maxBackups", ["type", "int"]]
       - - mapfield
         - credentials
         - (( types.etcd_backup[values.type].credentials ))

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -89,8 +89,8 @@ etcd:
         etcd-backup-restore: (( .landscape.versions.etcd.backup_restore.image_repo ":" .landscape.versions.etcd.backup_restore.image_tag ))
 
       backup:
-        schedule: "0 */24 * * *" # cron standard schedule
-        maxBackups: 7 # Maximum number of backups to keep (may change in future)
+        schedule: (( defined(landscape.etcd.backup.schedule) ? landscape.etcd.backup.schedule :"0 */24 * * *" )) # Backup interval (default 24h)
+        maxBackups: (( defined(landscape.etcd.backup.maxBackups) ? landscape.etcd.backup.maxBackups :7 )) # Maximum number of backups to keep (default 7)
         storageProvider: (( landscape.etcd.backup.active ? spec.providertypes.[landscape.etcd.backup.type] :"" ))  # Abs,Gcs,S3,Swift empty means no backup,
         secretData: (( sum[temp.config.credentials|{}|c,k,v|->c {k=base64(v)}] ))
         storageContainer: (( landscape.etcd.backup.active ? imports.backupinfra.export.bucketname :~ ))


### PR DESCRIPTION
**What this PR does / why we need it**:

The two parameters `maxBackups` and `schedule` for the `ectd/cluster` component already exist, but are only set to default values in the component's `deployment.yaml`.

**Which issue(s) this PR fixes**:

This PR introduces the fields as optional configuration options in the `acre.yaml` to allow for custom backup intervals and retention times. If the fields are not provided, the default values are used (so no behavior change for existing configs).

**Special notes for your reviewer**:

none

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Make ectd maxBackups and schedule fields optional configuration options in acre.yaml
```
