### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Gardener uses Kubernetes to manage Kubernetes clusters. This documentation describes how to install Gardener on an existing Kubernetes cluster of your IaaS provider.
 > Where reference is made in this document to the *base cluster*, we are actually referring to the existing cluster where you will install Gardener. This helps to distinguish them from the clusters that you will create after the installation using Gardener. Once it's installed, it is also referred to as *garden cluster*. Whenever you create clusters, Gardener will create *seed clusters* and *shoot clusters*. In this documentation we will only cover the installation of clusters in one region of one IaaS provider. More information: [Architecture](https://gardener.cloud/documentation/030-architecture/).
 
+## Disclaimer: Productive Use
+
+Please be aware that garden-setup was created with the intent of providing an easy way to install Gardener for the purpose of "having a look into it". While it offers lots of configuration options and can be used to create landscapes , garden-setup lacks some features which are usually expected from a 'productive' installer. The most prominent example is that garden-setup *does not have any built-in support for upgrading an existing landscape*. You can 'deploy over' an existing landscape with a new version of garden-setup (or one of its components), but this scenario is not tested or validated in any way, and might or might not work.
+
 ## Prerequisites
 
 * The installation was tested on Linux and MacOS

--- a/acre.yaml
+++ b/acre.yaml
@@ -26,8 +26,11 @@ landscape:
   components: []
   versions:
     kube-apiserver:
-      image_repo: k8s.gcr.io/hyperkube
-      image_tag: v1.18.3
+      image_repo: k8s.gcr.io/kube-apiserver
+      image_tag: v1.19.15
+    kube-controller-manager:
+      image_repo: k8s.gcr.io/kube-controller-manager
+      image_tag: (( kube-apiserver.image_tag ))
     etcd:
       etcd:
         image_repo: quay.io/coreos/etcd

--- a/components/gardencontent/gardenproject/deployment.yaml
+++ b/components/gardencontent/gardenproject/deployment.yaml
@@ -67,6 +67,8 @@ secret_template:
           cloudprofile.garden.sapcloud.io/name: (( v.name ))
         name: (( secretname ))
         namespace: (( .settings.project_namespace ))
+      provider:
+        type: (( v.type ))
       secretRef:
         name: (( secretname ))
 

--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -34,7 +34,7 @@ spec:
         checksum/secret-kube-aggregator-client: {{ include (print $.Template.BasePath "/secret-kube-aggregator-client-tls.yaml") . | sha256sum }}
         checksum/secret-kube-apiserver-ca: {{ include (print $.Template.BasePath "/secret-kube-apiserver-ca.yaml") . | sha256sum }}
         checksum/secret-kube-apiserver-server: {{ include (print $.Template.BasePath "/secret-kube-apiserver-server-tls.yaml") . | sha256sum }}
-        checksum/secret-kube-apiserver-basic-auth: {{ include (print $.Template.BasePath "/secret-kube-apiserver-basic-auth.yaml") . | sha256sum }}
+        checksum/secret-kube-apiserver-static-token: {{ include (print $.Template.BasePath "/secret-kube-apiserver-static-token.yaml") . | sha256sum }}
         checksum/secret-kube-controller-manager-client: {{ include (print $.Template.BasePath "/secret-kube-controller-manager-tls.yaml") . | sha256sum }}
         checksum/secret-service-account-key: {{ include (print $.Template.BasePath "/secret-service-account-key.yaml") . | sha256sum }}
         {{- if .Values.tls.identity.ca }}
@@ -76,17 +76,16 @@ spec:
         operator: Exists
       containers:
       - name: kube-apiserver
-        image: {{ index .Values.images "hyperkube" }}
+        image: {{ index .Values.images "apiserver" }}
         imagePullPolicy: IfNotPresent
         command:
-        - /hyperkube
-        - kube-apiserver
+        - /usr/local/bin/kube-apiserver
         - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,PodSecurityPolicy,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false
         - --authorization-mode=Node,RBAC
-        - --basic-auth-file=/srv/kubernetes/auth/basic_auth.csv
+        - --token-auth-file=/srv/kubernetes/token/static_tokens.csv
         - --client-ca-file=/srv/kubernetes/ca/ca.crt
         - --enable-aggregator-routing=true
         - --enable-bootstrap-token-auth=true
@@ -128,7 +127,7 @@ spec:
             port: 443
             httpHeaders:
             - name: Authorization
-              value: Basic {{ printf "admin:%s" .Values.tls.kubeAPIServer.basicAuthPassword | b64enc }}
+              value: Bearer {{ .Values.tls.kubeAPIServer.staticTokens.healthCheck }}
           successThreshold: 1
           failureThreshold: 3
           initialDelaySeconds: 15
@@ -141,7 +140,7 @@ spec:
             port: 443
             httpHeaders:
             - name: Authorization
-              value: Basic {{ printf "admin:%s" .Values.tls.kubeAPIServer.basicAuthPassword | b64enc }}
+              value: Bearer {{ .Values.tls.kubeAPIServer.staticTokens.healthCheck }}
           successThreshold: 1
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -173,8 +172,8 @@ spec:
           mountPath: /srv/kubernetes/apiserver
         - name: service-account-key
           mountPath: /srv/kubernetes/service-account-key
-        - name: kube-apiserver-basic-auth
-          mountPath: /srv/kubernetes/auth
+        - name: kube-apiserver-static-token
+          mountPath: /srv/kubernetes/token
         - name: kube-aggregator
           mountPath: /srv/kubernetes/aggregator
         {{- if .Values.tls.identity.ca }}
@@ -182,11 +181,10 @@ spec:
           mountPath: /srv/kubernetes/identity-ca
         {{- end }}
       - name: kube-controller-manager
-        image: {{ index .Values.images "hyperkube" }}
+        image: {{ index .Values.images "controllermanager" }}
         imagePullPolicy: IfNotPresent
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /usr/local/bin/kube-controller-manager
         - --cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt
         - --cluster-signing-key-file=/srv/kubernetes/ca/ca.key
         - --controllers=namespace,serviceaccount,serviceaccount-token,clusterrole-aggregation,garbagecollector,csrapproving,csrcleaner,csrsigning,bootstrapsigner,tokencleaner,resourcequota
@@ -251,9 +249,9 @@ spec:
       - name: etcd-client-tls
         secret:
           secretName: {{ .Values.etcd.secretNames.client | default "garden-etcd-client" }}
-      - name: kube-apiserver-basic-auth
+      - name: kube-apiserver-static-token
         secret:
-          secretName: garden-kube-apiserver-basic-auth
+          secretName: garden-kube-apiserver-static-token
       - name: service-account-key
         secret:
           secretName: garden-service-account-key

--- a/components/kube-apiserver/chart/templates/secret-kube-apiserver-static-token.yaml
+++ b/components/kube-apiserver/chart/templates/secret-kube-apiserver-static-token.yaml
@@ -15,8 +15,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: garden-kube-apiserver-basic-auth
+  name: garden-kube-apiserver-static-token
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  basic_auth.csv: {{ printf "%s,admin,admin,system:masters" .Values.tls.kubeAPIServer.basicAuthPassword | b64enc }}
+  static_tokens.csv: {{ printf "%s,kube-apiserver-health-check,kube-apiserver-health-check," .Values.tls.kubeAPIServer.staticTokens.healthCheck | b64enc }}

--- a/components/kube-apiserver/chart/values.yaml
+++ b/components/kube-apiserver/chart/values.yaml
@@ -15,7 +15,8 @@
 namespace: xxx
 serviceName: garden-kube-apiserver
 images:
-  hyperkube: k8s.gcr.io/hyperkube:v1.15.10
+  apiserver: k8s.gcr.io/kube-apiserver:v1.19.15
+  controllermanager: k8s.gcr.io/kube-controller-manager:v1.19.15
 
 replicas: 3
 apiServer:
@@ -31,7 +32,8 @@ tls:
     server:
       crt: server-certificate
       key: server-key
-    basicAuthPassword: password
+    staticTokens:
+      healthCheck: token
   kubeControllerManager:
     crt: client-certificate
     key: client-key

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -36,7 +36,7 @@ spec:
 
   new:
     service_account_key: (( &template(x509genkey()) ))
-    basic_auth:          (( &template(exec( "bash", "-c", "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1" )) ))
+    static_token:          (( &template(exec( "bash", "-c", "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 128 | head -n 1" )) ))
 
   server:
     commonName: "garden:server:kube-apiserver"
@@ -84,7 +84,7 @@ state:
   kube_aggregator_ca:          (( utilities.certs.selfSignedCA("garden:ca:kube-aggregator", false) ))
   kube_aggregator_client:      (( utilities.certs.keyCertForCA(spec.aggregator_client, kube_aggregator_ca, false) ))
   service_account_key:         (( utilities.state.valuedata(~,spec.new.service_account_key,false) ))
-  basic_auth:                  (( utilities.state.valuedata(~,spec.new.basic_auth, false) ))
+  static_token_health_check:   (( utilities.state.valuedata(~,spec.new.static_token, false) ))
 
 
 kubeapiserver:
@@ -97,7 +97,8 @@ kubeapiserver:
   serviceName: (( name ))
   values:
     images:
-      hyperkube: (( .landscape.versions.kube-apiserver.image_repo ":" .landscape.versions.kube-apiserver.image_tag ))
+      apiserver: (( .landscape.versions.kube-apiserver.image_repo ":" .landscape.versions.kube-apiserver.image_tag ))
+      controllermanager: (( .landscape.versions.kube-controller-manager.image_repo ":" .landscape.versions.kube-controller-manager.image_tag ))
     apiServer:
       hostname: (( .settings.apiserver_dns ))
       serviceName: (( name ))
@@ -106,7 +107,8 @@ kubeapiserver:
       kubeAPIServer:
         ca: (( spec.KeyCert(.state.kube_apiserver_ca) ))
         server: (( spec.KeyCert(.state.kube_apiserver_server) )) 
-        basicAuthPassword: (( .state.basic_auth.value ))
+        staticTokens:
+          healthCheck: (( .state.static_token_health_check.value ))
       kubeAggregator:
         ca: (( spec.KeyCert(.state.kube_aggregator_ca) ))
         client: (( spec.KeyCert(.state.kube_aggregator_client) ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.38.4"
+        "version": "v1.38.5"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.52.3"
+        "version": "1.54.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.37.4"
+        "version": "v1.38.4"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -40,7 +40,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.19.2"
+          "version": "v1.20.0"
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -60,7 +60,7 @@
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
-          "version": "v0.3.0"
+          "version": "v0.4.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.16.0"
+          "version": "v1.17.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.19.0"
+          "version": "v1.20.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.32.0"
+          "version": "v1.32.1"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -56,7 +56,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.11.0"
+          "version": "v0.12.0"
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
-          "version": "v0.10.0"
+          "version": "v0.11.0"
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.23.1"
+          "version": "v1.24.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.13.0"
+          "version": "v1.14.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -20,7 +20,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.14.0"
+          "version": "v1.15.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.38.5`
```
```feature operator
Upgrade virtual kube-apiserver to `v1.19.15`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.20.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.12.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.17.0`
```
```other operator
Upgrade Gardener extension runtime-gvisor to `v0.4.0`
```
```other operator
Upgrade Gardener extension os-gardenlinux to `v0.11.0`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.15.0`
```
```feature operator
Upgrade Gardener dashboard to `1.54.0`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.20.0`
```
```other operator
Upgrade Gardener extension  to `v1.24.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.32.1`
```


