### PR TITLE
Make all cert-manager image registries configurable

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -206,6 +206,16 @@ landscape:
         repo: "https://github.com/jetstack/cert-manager.git"
         helm_repo: "https://charts.jetstack.io"
         helm_tag: "v1.3.1"
+      cainjector:
+        <<: (( merge ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :cert-manager.controller.helm_tag ))
+        image_tag: (( valid( tag ) ? tag :~~ ))
+        image_repo: (( ~~ ))
+      webhook:
+        <<: (( merge ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :cert-manager.controller.helm_tag ))
+        image_tag: (( valid( tag ) ? tag :~~ ))
+        image_repo: (( ~~ ))
       cert-dns-bridge:
         <<: (( merge ))
         tag: (( valid( branch ) -or valid( commit ) ? ~~ :"2.0.0" ))

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -130,6 +130,14 @@ helm:
     image:
       repository: (( .landscape.versions.cert-manager.controller.image_repo || ~~ ))
       tag: (( .landscape.versions.cert-manager.controller.image_tag || ~~ ))
+    cainjector:
+      image:
+        repository: (( .landscape.versions.cert-manager.cainjector.image_repo || ~~ ))
+        tag: (( .landscape.versions.cert-manager.cainjector.image_tag || ~~ ))
+    webhook:
+      image:
+        repository: (( .landscape.versions.cert-manager.webhook.image_repo || ~~ ))
+        tag: (( .landscape.versions.cert-manager.webhook.image_tag || ~~ ))
     serviceAccount:
       create: true
       name: (( .settings.serviceAccountName ))


### PR DESCRIPTION
**What this PR does / why we need it**:

When trying to provide all needed images in a self-hosted registry, it turns out that the cert-manager still pulls two images from `quay.io`: `cert-manager-cainjector` and `cert-manager-webhook`. Only the `cert-manager-controller` image can be configured in the `acre.yaml`.

**Which issue(s) this PR fixes**:

This PR makes it possible to also configure a custom `image_repo` and `image_tag` for these two images. The fallback is to take the hard-coded `helm_tag` of the `cert-manager.controller` as the `image_tag` and the default Helm chart values for the `registry`, which means no changes are necessary if you want to keep pulling from `quay.io`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Make all cert-manager image registries configurable
```
