### PR TITLE
Upgrade Gardener

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -601,12 +601,9 @@ validation:
       - - optionalfield
         - featureGates
         - - and
-          - ["optionalfield", "Logging", ["type", "bool"]]
           - ["optionalfield", "HVPA", ["type", "bool"]]
           - ["optionalfield", "HVPAForShootedSeed", ["type", "bool"]]
           - ["optionalfield", "ManagedIstio", ["type", "bool"]]
-          - ["optionalfield", "ManagedIstio", ["type", "bool"]]
-          - ["optionalfield", "APIServerSNI", ["type", "bool"]]
           - ["optionalfield", "APIServerSNI", ["type", "bool"]]
           - ["optionalfield", "CachedRuntimeClients", ["type", "bool"]]
           - ["optionalfield", "SeedChange", ["type", "bool"]]
@@ -668,6 +665,10 @@ validation:
       - - mapfield
         - credentials
         - (( types.iaas[values.type].credentials ))
+      - - optionalfield
+        - logging
+        - - and
+          - ["optionalfield", "enabled", ["type", "bool"]]
       - - optionalfield
         - seedConfig
         - - and

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -231,7 +231,7 @@ gardenletSpec:
         featureGates: 
           <<: (( configValues.config.featureGates || {} ))
           ManagedIstio: (( pluginSpecs.managedIstioActive ))
-          APIServerSNI: (( configValues.config.featureGates.APIServerSNI || false ))
+          APIServerSNI: (( configValues.config.featureGates.APIServerSNI || true ))
         seedConfig:
           metadata:
             name: (( configValues.name ))
@@ -253,7 +253,7 @@ monitoringTemplate:
       <<: (( configValues.monitoring.externalLabels || {} ))
 
 pluginSpecs:
-  managedIstioActive: (( configValues.config.featureGates.ManagedIstio || false ))
+  managedIstioActive: (( configValues.config.featureGates.ManagedIstio || true ))
   deploySecrets:
     kubeconfig: (( configValues.kubeconfigs.virtual ))
     manifests: (( secretManifests ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -230,7 +230,6 @@ gardenletSpec:
         kubernetesLogLevel: 0
         featureGates: 
           <<: (( configValues.config.featureGates || {} ))
-          Logging: (( configValues.config.featureGates.Logging || true ))
           ManagedIstio: (( pluginSpecs.managedIstioActive ))
           APIServerSNI: (( configValues.config.featureGates.APIServerSNI || false ))
         seedConfig:

--- a/components/gardencontent/seeds/provider/openstack/shoot.yaml
+++ b/components/gardencontent/seeds/provider/openstack/shoot.yaml
@@ -17,7 +17,7 @@ infrastructureConfig:
   kind: InfrastructureConfig
   networks:
     workers: (( values.config.cluster.networks.workers ))
-  floatingPoolName: (( values.config.floatingPools[0].name))
+  floatingPoolName: (( values.config.floatingPoolName || values.config.floatingPools[0].name ))
 controlPlaneConfig:
   apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
   kind: ControlPlaneConfig

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -80,7 +80,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.17.0"
+          "version": "v0.18.0"
         }
       }
     }

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -71,7 +71,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.54.0"
+        "version": "1.55.1"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.40.4"
+        "version": "v1.41.8"
       },
       "extensions": {
         "dns-external": {

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -400,6 +400,8 @@ All of the Openstack-specific nodes go into the [cloudprofile](https://github.co
 
 The version inside the ``machineImageDefinitions`` and ``machineImages`` sections has to be specified using the [semantic versioning](https://semver.org) format.
 
+For nested Openstack entries, the floating pool name which should be used for the shoot for the shooted seed can be specified by setting `floatingPoolName` in the nested iaas entry. If not specified, the first entry of the `floatingPools` list will be used.
+
 > Keep in mind that you can reference cloudprofiles created by other iaas entries (see [cloudprofile](#the-cloudprofile-field)). If you reference another cloudprofile, none will be created for the current iaas entry and you can leave out all of the provider-specific configuration. You can also use [spiff++ templating](https://github.com/mandelsoft/spiff) to reduce redundancy.
 
 

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -6,8 +6,9 @@ iaas:
     type: <gcp|aws|azure|alicloud|openstack>              # iaas provider
     mode: <seed|soil>                            # optional, defaults to 'seed'
     cloudprofile: <name of cloudprofile>         # optional, will deploy its own cloudprofile if not specified
-    featureGates:                                # optional, set featureGates for the gardenlet. Logging is enable by default
-      Logging: true
+    featureGates:                                # optional, set featureGates for the gardenlet
+      ManagedIstio: false
+      APIServerSNI: false
     shootDefaultNetworks:                        # optional, overwrites defaults of .spec.networks.shootDefaults in the seed manifest
       pods: 100.96.0.0/11
       services: 100.64.0.0/13
@@ -43,6 +44,7 @@ iaas:
       verticalPodAutoscaler:
         enabled: true
     logging:                                     # optional, configure logging settings for the gardenlet
+    # enabled: false
     # fluentBit:                                 # example for FluentBit
     #   output: |-
     #     [Output]
@@ -91,8 +93,11 @@ Cloudprofiles are created first, before any seed. Thus, entries of `landscape.ia
 
 ## The 'featureGates' Field
 
-The `featureGates` field enable/disable featureGates for the gardenlet. By default - that means there is no `featureGates` field or no value for `featureGates.Logging` - the `Logging` featureGate will be enabled. To diasble the `Logging` featureGate you have to set the `featureGates.Logging` to `false`.
-A list of available featureGates you can find in the gardener documentation - [Feature Gates in Gardener](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)
+The `featureGates` field enable/disable featureGates for the gardenlet. A list of available featureGates you can find in the gardener documentation - [Feature Gates in Gardener](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)
+
+## The 'logging' Field
+
+The `logging` field contains configuration for the logging behaviour of the gardenlet - [20-componentconfig-gardenlet.yaml](https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml)
 
 ## The 'seedSettings' Field
 

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -7,8 +7,8 @@ iaas:
     mode: <seed|soil>                            # optional, defaults to 'seed'
     cloudprofile: <name of cloudprofile>         # optional, will deploy its own cloudprofile if not specified
     featureGates:                                # optional, set featureGates for the gardenlet
-      ManagedIstio: false
-      APIServerSNI: false
+      ManagedIstio: true
+      APIServerSNI: true
     shootDefaultNetworks:                        # optional, overwrites defaults of .spec.networks.shootDefaults in the seed manifest
       pods: 100.96.0.0/11
       services: 100.64.0.0/13


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.41.8`
```
```other operator
Upgrade Gardener Dashboard to `1.55.1`
```
```other operator
Upgrade terminal-controller-manager to `v0.18.0`
```
```feature operator
It is now possible to manually set the floatingPool name for openstack shooted seeds by specifying `floatingPoolName` in the shooted seed configuration.
```
```breaking operator
The `ManagedIstio` and `APIServerSNI` feature gates for gardenlets are now activated by default. This should not be a breaking change for most cases, but there might be ones where it is.
```