### PR TITLE
update cert-manager resources and certificate-dns-bridge for k8s 1.22

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -212,7 +212,7 @@ landscape:
         tag: (( valid( branch ) -or valid( commit ) ? ~~ :helm_tag )) # only used for CRDs
         repo: "https://github.com/jetstack/cert-manager.git"
         helm_repo: "https://charts.jetstack.io"
-        helm_tag: "v1.3.1"
+        helm_tag: "v1.8.1"
       cainjector:
         <<: (( merge ))
         tag: (( valid( branch ) -or valid( commit ) ? ~~ :cert-manager.controller.helm_tag ))
@@ -225,7 +225,7 @@ landscape:
         image_repo: (( ~~ ))
       cert-dns-bridge:
         <<: (( merge ))
-        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"2.0.0" ))
+        tag: (( valid( branch ) -or valid( commit ) ? ~~ :"2.1.0" ))
         image_tag: (( valid( tag ) ? tag :~~ ))
         image_repo: (( ~~ ))
         repo: "https://github.com/gardener/certificate-dns-bridge.git"

--- a/components/cert-manager/cert/deployment.yaml
+++ b/components/cert-manager/cert/deployment.yaml
@@ -18,7 +18,7 @@ plugins:
 cert:
   kubeconfig: (( .landscape.clusters[0].kubeconfig ))
   manifests:
-    - apiVersion: cert-manager.io/v1alpha2
+    - apiVersion: cert-manager.io/v1
       kind: Certificate
       metadata:
         name: (( .settings.certificate.name ))

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -68,7 +68,7 @@ acme_issuer:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   manifests:
     - <<: (( valid( .settings.issuerPrivateKey ) ? *issuer-secret :~ ))
-    - apiVersion: cert-manager.io/v1alpha2
+    - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
         name: (( settings.issuerName ))
@@ -101,7 +101,7 @@ ca_issuer:
       data:
         tls.crt: (( base64( .settings.ca.crt ) ))
         tls.key: (( base64( .settings.ca.key ) ))
-    - apiVersion: cert-manager.io/v1alpha2
+    - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
         name: (( settings.issuerName ))


### PR DESCRIPTION
update cert-manager resources and certificate-dns-bridge to k8s 1.22 compatible versions

Signed-off-by: Christian Hüning <christian.huening@finleap.com>

**What this PR does / why we need it**:
This updates cert-manager ressources and the certificate-dns-bridge dependecy to versions which are compatible with K8s 1.22.x

**Which issue(s) this PR fixes**:
fixes #813 

**Special notes for your reviewer**:
The [certificate-bridge-dns](https://github.com/gardener/certificate-dns-bridge/) version `2.1.0` is not yet released

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
* garden-setup is now compatible with Kubernetes 1.22.x
```
