### PR TITLE
add admission controller for shoot-dns-service extension

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -152,6 +152,7 @@ landscape:
           tag: (( valid( shoot-dns-service.branch ) -or valid( shoot-dns-service.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.shoot-dns-service.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.shoot-dns-service.repo ))
           chart_path: charts/gardener-extension-shoot-dns-service
+          admission_chart_path: charts/gardener-extension-admission-shoot-dns-service
           image_tag: (( valid( shoot-dns-service.tag ) ? shoot-dns-service.tag :~~ ))
           image_repo: (( ~~ ))
         provider-vsphere:

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -7,7 +7,10 @@ component:
     - kube_apiserver: "kube-apiserver"
     - namespace
 
-  stubs: []
+  stubs:
+    - lib/templates/utilities.yaml
+    - lib/templates/state.yaml
+    - lib/templates/certs.yaml
 
   plugins:
     - <<: (( sum[.extensions|[]|s,n,v|-> s [{ "-echo" = "--------------------------------------------------" }, { "-echo" = "checking out charts for extension '" n "'" }, { "git" = "extensions." n }]] ))
@@ -24,12 +27,14 @@ spec_template:
   commit: (( version.commit || ~~ ))
   files:
     - (( version.chart_path ))
+    - (( contains( deployment.admissionControllers, n ) ? version.admission_chart_path :~~ ))
 
 deployment:
   # which extensions should be deployed
   # all need a matching node in landscape.versions.gardener.extensions in the acre.yaml file
   # and a manifest template in extension_manifests in this component's deployment.yaml
   extensions: (( uniq( sum[.default_extensions|[]|s,e|->s ( contains(.deactivated_extensions, e) ? ~ :e )] .activated_extensions ) ))
+  admissionControllers: (( uniq( intersect( extensions, .admissionControllers ) ) ))
 
 default_extensions:
   - os-ubuntu
@@ -42,5 +47,7 @@ default_extensions:
   - (( ( .landscape.dashboard.terminals.active || false ) ? "shoot-cert-service" :~~ ))
 activated_extensions: (( valid( landscape.gardener.extensions ) ? keys(select{landscape.gardener.extensions|e|-> valid( e.active ) -and ( e.active == true )}) :[] ))
 deactivated_extensions: (( valid( landscape.gardener.extensions ) ? keys(select{landscape.gardener.extensions|e|-> valid( e.active ) -and ( e.active == false )}) :[] ))
+
+admissionControllers: (( &temporary ( valid( landscape.gardener.extensions ) ? sum[landscape.gardener.extensions|[]|s,k,v|-> valid( v.admissionController ) -and ( v.admissionController == true ) -and valid( landscape.versions.gardener.extensions[k].admission_chart_path ) ? s k :s] :[] ) ))
 
 infrastructures: (( &temporary ( uniq( sum[.landscape.iaas|[]|s,e|-> s e.type ( e.seeds.[*].type || ~ ) ] ) ) ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -2,16 +2,20 @@
 imports: (( &temporary ))
 landscape: (( &temporary ))
 env: (( &temporary ))
+utilities: (( &temporary ))
 
 plugins:
   - kubectl
+  - (( ( length(.admissionControllers) > 0 ) -and ( .landscape.gardener.network-policies.active == true ) ? { "kubectl" = "kubectl_admission_netpols" } :~~ )) # network policies for admission controllers
+  - <<: (( length(.admissionControllers) > 0 ? sum[.admissionControllers|[]|s,n|-> *.admission.plugin_template] :~ )) # admission controllers
   - shoot-check
 
 shoot-check:
   kubeconfig: (( imports.kube_apiserver.export.kubeconfig ))
 
-# list of extensions taken from component.yaml (deployment.extensions)
+# list of extensions/admissionControllers taken from component.yaml (deployment.extensions)
 extensions: (( &temporary ))
+admissionControllers: (( &temporary ))
 
 # instantiated manifest templates
 rendered_extension_manifests: (( &temporary( sum[extensions|{}|s,n|-> s { n = *.spec_template }] ) ))
@@ -28,6 +32,10 @@ extension_controllers_func:
 kubectl:
   kubeconfig: (( imports.kube_apiserver.export.kubeconfig ))
   manifests: (( sum[rendered_extension_manifests.[*].manifests|[]|s,e|->s e.[*]] ))
+
+kubectl_admission_netpols:
+  kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  manifests: (( sum[.admissionControllers|[]|s,n|-> s *.admission.netpol_template] ))
 
 # this template gets evaluated for each entry in extension_manifests
 spec_template:
@@ -67,6 +75,108 @@ manifest_templates:
         policy: OnDemand
       resources: (( data.resources ))
 
+state:
+  <<: (( &state(merge none) ))
+  admissionCertificates: (( sum[.admissionControllers|{}|s,n|-> s { n = *.admission.cert_data.state_template }] ))
+
+rendered_admission_templates:
+  helm_virtual: (( sum[.admissionControllers|{}|s,n|-> s { n = *admission.helm_template_virtual }] ))
+  kubectl_virtual: (( sum[.admissionControllers|{}|s,n|-> s { n = *admission.kubectl_template_virtual }] ))
+  helm_runtime: (( sum[.admissionControllers|{}|s,n|-> s { n = *admission.helm_template_runtime }] ))
+
+# stuff required for the extension admission controllers
+admission:
+  <<: (( &temporary ))
+
+  fullName: (( |n|-> "gardener-extension-admission-" n ))
+
+  # virtual cluster deployment
+  helm_template_virtual:
+    <<: (( &template ))
+    kubeconfig: (( .imports.kube_apiserver.export.kubeconfig ))
+    source: (( "extensions." n "/repo/charts/" admission.fullName(n) "/charts/application" ))
+    name: (( admission.fullName(n) ))
+    namespace: (( .landscape.namespace ))
+    values: (( *admission.values_template ))
+  helm_template_runtime:
+    <<: (( &template ))
+    kubeconfig: (( .landscape.clusters.[0].kubeconfig ))
+    source: (( "extensions." n "/repo/charts/" admission.fullName(n) "/charts/runtime" ))
+    name: (( admission.fullName(n) ))
+    namespace: (( .landscape.namespace ))
+    values: (( *admission.values_template ))
+  kubectl_template_virtual:
+    <<: (( &template ))
+    kubeconfig: (( .imports.kube_apiserver.export.kubeconfig ))
+    files:
+      - (( "rendered_admission_templates.helm_virtual." n "/rendered_charts.yaml" ))
+  plugin_template:
+    - <<: (( &template ))
+    - pinned:
+      - helm:
+        - (( "rendered_admission_templates.helm_virtual." n ))
+        - template
+      - kubectl: (( "rendered_admission_templates.kubectl_virtual." n ))
+    - helm: (( "rendered_admission_templates.helm_runtime." n ))
+
+  # certificate stuff
+  cert_data:
+    <<: (( &temporary ))
+    server:
+      <<: (( &template ))
+      commonName: (( admission.fullName(n) ".garden.svc.cluster.local" ))
+      validity: 87600
+      usage:
+        - ServerAuth
+        - Signature
+        - KeyEncipherment
+      hosts:
+        - (( admission.fullName(n) ))
+        - (( admission.fullName(n) ".garden" ))
+        - (( admission.fullName(n) ".garden.svc" ))
+        - (( admission.fullName(n) ".garden.svc.cluster" ))
+        - (( admission.fullName(n) ".garden.svc.cluster.local" ))
+      
+    state_template:
+      <<: (( &template ))
+      ca: (( utilities.certs.selfSignedCA(admission.fullName(n), false) ))
+      server: (( utilities.certs.keyCertForCA(*.admission.cert_data.server, ca, false) ))
+
+  # admission controller values template
+  values_template:
+    <<: (( &template ))
+    global:
+      virtualGarden:
+        enabled: true
+      kubeconfig: (( asyaml( .imports.kube_apiserver.export.kubeconfig ) ))
+      image:
+        repository: (( .landscape.versions.gardener.extensions[n].image_repo || ~~ ))
+        tag: (( .landscape.versions.gardener.extensions[n].image_tag || ~~ ))
+      replicaCount: 3
+      webhookConfig:
+        caBundle: (( .state.admissionCertificates[n].ca.value.cert ))
+        tls:
+          crt: (( .state.admissionCertificates[n].server.value.cert ))
+          key: (( .state.admissionCertificates[n].server.value.key ))
+
+  netpol_template:
+    <<: (( &template ))
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: (( "to-" n "-admission-controller" ))
+      namespace: (( .landscape.namespace ))
+    spec:
+      podSelector:
+        matchLabels:
+          networking.gardener.cloud/to-gardener-extension-admission-controllers: allowed
+      policyTypes:
+      - Egress
+      egress:
+      - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: (( admission.fullName(n) ))
 
 extension_specs:
   <<: (( &temporary ))

--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -53,6 +53,7 @@ spec:
         networking.gardener.cloud/to-terminal-controller-manager: allowed # needed for webhooks
         networking.gardener.cloud/to-world: allowed # necessary, except for GCP because GCP puts IP table rules on the nodes that allow in-cluster routing
         networking.gardener.cloud/to-gardener-admission-controller: allowed # needed for webhooks
+        networking.gardener.cloud/to-gardener-extension-admission-controllers: allowed # needed for extension admission controllers, if activated
         {{- end }}
     spec:
       affinity:

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -17,6 +17,12 @@ The `landscape.gardener.extensions` is optional.
 
 While garden-setup automatically decides which Gardener extensions to deploy, it is possible to overwrite this decision manually. By setting `landscape.gardener.<extension_name>.active` to `true`, the extension will be deployed, independently of whether it is needed or not. Similarly, setting the flag to `false` will deactivate the extension and it won't be deployed. You should handle the latter one with care, as most extensions which are deployed by default are needed and deactivating them will result in a broken Gardener landscape.
 
+#### Admission Controllers
+
+Some extensions come with admission controllers which can be deployed into the base cluster optionally. For chosen extensions, garden-setup is able to deploy the admission controller. To do this, it needs to be activated manually by setting `landscape.gardener.<extension_name>.admissionController` to `true`.
+
+Currently, this feature is only enabled for the `shoot-dns-service` extension.
+
 #### valueOverwrites for Extensions
 
 Whatever is specified in `landscape.gardener.extensions.<extensionName>.valueOverwrites` will be given directly to the helm values for the extension, so you can overwrite the corresponding default values. 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the admission controller for the shoot-dns-service extension. This is done in a way that makes it easy to enable admission controllers for other extension too, as long as they are deployed in a similar fashion.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It's now possible to deploy the admission controller for the `shoot-dns-service` extension.
```
