### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
+++ b/components/kube-apiserver/chart/templates/service-kube-apiserver-ingress.yaml
@@ -18,6 +18,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     kubernetes.io/ingress.class: "nginx"
+  finalizers:
+  - "garden-setup.gardener.cloud/prevent-deletion"
   name: apiserver-ingress
   namespace: {{ .Release.Namespace }}
 spec:

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -23,12 +23,21 @@ plugins:
       - kubeapiserver
       - template
     - kubectl: kubeapiserver
+  - finalize
 
 settings:
   apiserver_dns: (( "api." imports.ingress_controller.export.ingress_domain ))
   gardener_dns: (( "gardener." imports.ingress_controller.export.ingress_domain ))
   apiserver_url_internal: (( "https://" .kubeapiserver.serviceName "." .kubeapiserver.namespace ".svc:443" ))
-  
+
+finalize:
+  kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+  type: ingress
+  name: apiserver-ingress
+  namespace: (( .landscape.namespace ))
+  finalizers:
+  - "garden-setup.gardener.cloud/prevent-deletion"
+
 spec:
   <<: (( &temporary ))
 

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.53.2"
+        "version": "v1.53.4"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.52.3"
+        "version": "v1.53.2"
       },
       "extensions": {
         "dns-external": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -64,7 +64,7 @@
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
-          "version": "v0.5.1"
+          "version": "v0.6.0"
         }
       }
     },

--- a/plugins/finalize/plugin
+++ b/plugins/finalize/plugin
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2022 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This plugin removes one or more finalizers from a specified resource.
+# Removing will only happen on deletion.
+# Usage: Specify type, name, and optionally namespace of the resource. Provide a list of finalizers that should be removed from it. If the list contains either '*' or 'all', all finalizers will be removed.
+
+source "$SOWLIB/pluginutils"
+source "$SOWLIB/k8s"
+
+getRequiredValue type "type" PLUGINCONFIGJSON
+getRequiredValue name "name" PLUGINCONFIGJSON
+getValue namespace "namespace" PLUGINCONFIGJSON
+getValueList finalizers "finalizers" PLUGINCONFIGJSON
+K8S_setKubeConfig "$PLUGININSTANCE" "$dir/kubeconfig"
+
+finalize()
+{
+  info "removing finalizers from $type ${namespace:-}${namespace:+"/"}$name"
+  for fin in ${finalizers[@]}; do
+    if [[ "$fin" == '*' ]] || [[ "$fin" == 'all' ]]; then
+      echo "removing all finalizers"
+      exec_cmd kubectl ${namespace:+"--namespace="}${namespace:-} patch "$type" "$name" --type json --patch '[{"op": "remove", "path": "/metadata/finalizers"}]'
+      break
+    else
+      # determine index of specific finalizer
+      local index=$(kubectl ${namespace:+"--namespace="}${namespace:-} get "$type" "$name" -o json | jq '.metadata.finalizers | map(. == $fin) | index(true)' --arg fin "$fin")
+      if [[ "$index" == "null" ]]; then
+        echo "finalizer '$fin' does not exist"
+      else
+        echo "Removing finalizer '$fin' (index $index)"
+        exec_cmd kubectl ${namespace:+"--namespace="}${namespace:-} patch "$type" "$name" --type json --patch "[{\"op\": \"remove\", \"path\": \"/metadata/finalizers/$index\"}]"
+      fi
+    fi
+  done
+}
+
+case "$1" in
+    deploy)
+      verbose "Noting to do on deploy."
+      ;;
+    delete)
+      finalize
+      ;;
+    *) fail "unsupported action $1"
+esac


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.53.4`
```
```other operator
Upgrade Gardener extension runtime-gvisor to `v0.6.0`
```
```breaking operator
Due to a current workaround in Gardener (see https://github.com/gardener/gardener/pull/6293/commits/8c6399d93bcb372e74520127c2456e4193866862), Gardener will delete all ingress resources in the `garden` namespace of the seed cluster when removing a seed. This causes problems with garden-setup, where the ingress for the virtual cluster is located in the `garden` namespace on the base cluster, which is also used as seed cluster. To prevent the deletion of this ingress until the `kube-apiserver` component is deleted, a finalizer has been added to it. However, the ingress will still get a `deletionTimestamp`, which blocks most changes to the resource from then on. Most users should not be affected by this, but if you partially delete a garden-setup landscape, including the `gardencontent/seeds/soils` component but excluding the `kube-apiserver` component, you might run into problems when trying to update the `kube-apiserver` component later on.
```
