### PR TITLE
technical debt removal

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -8,8 +8,6 @@ ${ADD_DEPENDENCIES_CMD} \
     --component-dependencies \
     '{"name": "github.com/gardener/gardener", "version": "'$(jq -r ".versions.gardener.core.version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
-    '{"name": "github.com/gardener/external-dns-management", "version": "'$(jq -r ".versions.gardener.extensions[\"dns-external\"].version" <<< $DEP_VERSIONS)'"}' \
-    --component-dependencies \
     '{"name": "github.com/gardener/gardener-extension-networking-calico", "version": "'$(jq -r ".versions.gardener.extensions[\"networking-calico\"].version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
     '{"name": "github.com/gardener/gardener-extension-os-suse-chost", "version": "'$(jq -r ".versions.gardener.extensions[\"os-suse-chost\"].version" <<< $DEP_VERSIONS)'"}' \
@@ -37,6 +35,8 @@ ${ADD_DEPENDENCIES_CMD} \
     '{"name": "github.com/gardener/dashboard", "version": "'$(jq -r ".versions.dashboard.core.version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
     '{"name": "github.com/gardener/terminal-controller-manager", "version": "'$(jq -r ".versions.dashboard.terminals[\"terminal-controller-manager\"].version" <<< $DEP_VERSIONS)'"}' \
+    --component-dependencies \
+    '{"name": "github.com/gardener/external-dns-management", "version": "'$(jq -r ".versions[\"dns-controller-manager\"].version" <<< $DEP_VERSIONS)'"}' \
     --component-dependencies \
     '{"name": "github.com/gardener/sow", "version": "'$SOW_VERSION'"}' \
     --container-image-dependencies \

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -24,8 +24,6 @@ dep_version = os.getenv('DEPENDENCY_VERSION')
 
 if dep_name == 'github.com/gardener/gardener':
     set_dep_version(dep_version, 'versions', 'gardener', 'core', 'version')
-elif dep_name == 'github.com/gardener/external-dns-management':
-    set_dep_version(dep_version, 'versions', 'gardener', 'extensions', 'dns-external', 'version')
 elif dep_name == 'github.com/gardener/gardener-extension-networking-calico':
     set_dep_version(dep_version, 'versions', 'gardener', 'extensions', 'networking-calico', 'version')
 elif dep_name == 'github.com/gardener/gardener-extension-os-suse-chost':
@@ -54,6 +52,8 @@ elif dep_name == 'github.com/gardener/dashboard':
     set_dep_version(dep_version, 'versions', 'dashboard', 'core', 'version')
 elif dep_name == 'github.com/gardener/terminal-controller-manager':
     set_dep_version(dep_version, 'versions', 'dashboard', 'terminals', 'terminal-controller-manager', 'version')
+elif dep_name == 'github.com/gardener/external-dns-management':
+    set_dep_version(dep_version, 'versions', 'dns-controller-manager', 'version')
 elif dep_name == 'github.com/gardener/sow':
     with sow_version_file.open(mode='w') as f:
         f.write(dep_version)

--- a/acre.yaml
+++ b/acre.yaml
@@ -103,6 +103,7 @@ landscape:
           tag: (( valid( provider-aws.branch ) -or valid( provider-aws.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-aws.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.provider-aws.repo ))
           chart_path: charts/gardener-extension-provider-aws
+          admission_controller_name: gardener-extension-admission-aws
           image_tag: (( valid( provider-aws.tag ) ? provider-aws.tag :~~ ))
           image_repo: (( ~~ ))
         provider-alicloud:
@@ -110,6 +111,7 @@ landscape:
           tag: (( valid( provider-alicloud.branch ) -or valid( provider-alicloud.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-alicloud.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.provider-alicloud.repo ))
           chart_path: charts/gardener-extension-provider-alicloud
+          admission_controller_name: gardener-extension-admission-alicloud
           image_tag: (( valid( provider-alicloud.tag ) ? provider-alicloud.tag :~~ ))
           image_repo: (( ~~ ))
         provider-gcp:
@@ -117,6 +119,7 @@ landscape:
           tag: (( valid( provider-gcp.branch ) -or valid( provider-gcp.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-gcp.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.provider-gcp.repo ))
           chart_path: charts/gardener-extension-provider-gcp
+          admission_controller_name: gardener-extension-admission-gcp
           image_tag: (( valid( provider-gcp.tag ) ? provider-gcp.tag :~~ ))
           image_repo: (( ~~ ))
         provider-azure:
@@ -124,6 +127,7 @@ landscape:
           tag: (( valid( provider-azure.branch ) -or valid( provider-azure.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-azure.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.provider-azure.repo ))
           chart_path: charts/gardener-extension-provider-azure
+          admission_controller_name: gardener-extension-admission-azure
           image_tag: (( valid( provider-azure.tag ) ? provider-azure.tag :~~ ))
           image_repo: (( ~~ ))
         provider-openstack:
@@ -131,6 +135,7 @@ landscape:
           tag: (( valid( provider-openstack.branch ) -or valid( provider-openstack.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-openstack.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.provider-openstack.repo ))
           chart_path: charts/gardener-extension-provider-openstack
+          admission_controller_name: gardener-extension-admission-openstack
           image_tag: (( valid( provider-openstack.tag ) ? provider-openstack.tag :~~ ))
           image_repo: (( ~~ ))
         networking-calico:
@@ -138,6 +143,7 @@ landscape:
           tag: (( valid( networking-calico.branch ) -or valid( networking-calico.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.networking-calico.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.networking-calico.repo ))
           chart_path: charts/gardener-extension-networking-calico
+          admission_controller_name: gardener-extension-admission-calico
           image_tag: (( valid( networking-calico.tag ) ? networking-calico.tag :~~ ))
           image_repo: (( ~~ ))
         shoot-cert-service:
@@ -152,7 +158,7 @@ landscape:
           tag: (( valid( shoot-dns-service.branch ) -or valid( shoot-dns-service.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.shoot-dns-service.version ))
           repo: (( .dependency_versions.versions.gardener.extensions.shoot-dns-service.repo ))
           chart_path: charts/gardener-extension-shoot-dns-service
-          admission_chart_path: charts/gardener-extension-admission-shoot-dns-service
+          admission_controller_name: gardener-extension-admission-shoot-dns-service
           image_tag: (( valid( shoot-dns-service.tag ) ? shoot-dns-service.tag :~~ ))
           image_repo: (( ~~ ))
         provider-vsphere:

--- a/acre.yaml
+++ b/acre.yaml
@@ -63,13 +63,6 @@ landscape:
         image_repo: "eu.gcr.io/gardener-project/gardener/gardenlet"
         image_tag: (( valid( tag ) ? tag :~~ ))
       extensions:
-        dns-external:
-          <<: (( merge ))
-          tag: (( valid( dns-external.branch ) -or valid( dns-external.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))
-          image_tag: (( valid( dns-external.tag ) ? dns-external.tag :~~ ))
-          image_repo: (( ~~ ))
-          repo: (( .dependency_versions.versions.gardener.extensions.dns-external.repo ))
-          chart_path: charts/external-dns-management
         os-coreos:
           <<: (( merge ))
           tag: (( valid( os-coreos.branch ) -or valid( os-coreos.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.os-coreos.version ))
@@ -161,6 +154,9 @@ landscape:
           admission_controller_name: gardener-extension-admission-shoot-dns-service
           image_tag: (( valid( shoot-dns-service.tag ) ? shoot-dns-service.tag :~~ ))
           image_repo: (( ~~ ))
+          dns-controller-manager:
+            image_tag: (( valid( versions.dns-controller-manager.image_tag ) ? versions.dns-controller-manager.image_tag :~~ ))
+            image_repo: (( valid( versions.dns-controller-manager.image_repo ) ? versions.dns-controller-manager.image_repo :~~ ))
         provider-vsphere:
           <<: (( merge ))
           tag: (( valid( provider-vsphere.branch ) -or valid( provider-vsphere.commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.provider-vsphere.version ))
@@ -207,12 +203,12 @@ landscape:
       # to overwrite:
       # set image_repo here (mandatory)
       # set image_tag here (defaults to latest, if image_repo is set and image_tag is not given)
-    dns-controller:
+    dns-controller-manager:
       <<: (( merge ))
-      tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.gardener.extensions.dns-external.version ))
+      tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.dns-controller-manager.version ))
       image_tag: (( valid( tag ) ? tag :~~ ))
       image_repo: (( ~~ ))
-      repo: "https://github.com/gardener/external-dns-management.git"
+      repo: (( .dependency_versions.versions.dns-controller-manager.repo ))
     cert-manager:
       controller:
         <<: (( merge ))

--- a/components/dns-controller/component.yaml
+++ b/components/dns-controller/component.yaml
@@ -22,6 +22,6 @@ component:
     - git
 
 git:
-  <<: (( .landscape.versions.dns-controller ))
+  <<: (( .landscape.versions.dns-controller-manager ))
   files:
     - "charts"

--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -96,8 +96,8 @@ spec:
     nameOverride: (( settings.fullname ))
     fullnameOverride: (( settings.fullname ))
     image:
-      tag: (( .landscape.versions.dns-controller.image_tag || ~~ ))
-      repository: (( .landscape.versions.dns-controller.image_repo || ~~ ))
+      tag: (( .landscape.versions.dns-controller-manager.image_tag || ~~ ))
+      repository: (( .landscape.versions.dns-controller-manager.image_repo || ~~ ))
     createCRDs: true
     configuration:
       dnsClass: (( common.dns_class ))

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -40,7 +40,6 @@ default_extensions:
   - os-ubuntu
   - os-suse-chost
   - os-gardenlinux
-  - dns-external
   - networking-calico
   - runtime-gvisor
   - <<: (( sum[.infrastructures|[]|s,e|-> s [ "provider-" e ]] ))

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -27,7 +27,7 @@ spec_template:
   commit: (( version.commit || ~~ ))
   files:
     - (( version.chart_path ))
-    - (( contains( deployment.admissionControllers, n ) ? version.admission_chart_path :~~ ))
+    - (( contains( deployment.admissionControllers, n ) ? ( "charts/" version.admission_controller_name ) :~~ ))
 
 deployment:
   # which extensions should be deployed
@@ -48,6 +48,6 @@ default_extensions:
 activated_extensions: (( valid( landscape.gardener.extensions ) ? keys(select{landscape.gardener.extensions|e|-> valid( e.active ) -and ( e.active == true )}) :[] ))
 deactivated_extensions: (( valid( landscape.gardener.extensions ) ? keys(select{landscape.gardener.extensions|e|-> valid( e.active ) -and ( e.active == false )}) :[] ))
 
-admissionControllers: (( &temporary ( valid( landscape.gardener.extensions ) ? sum[landscape.gardener.extensions|[]|s,k,v|-> valid( v.admissionController ) -and ( v.admissionController == true ) -and valid( landscape.versions.gardener.extensions[k].admission_chart_path ) ? s k :s] :[] ) ))
+admissionControllers: (( &temporary ( valid( landscape.gardener.extensions ) ? sum[landscape.gardener.extensions|[]|s,k,v|-> valid( v.admissionController ) -and ( v.admissionController == true ) -and valid( landscape.versions.gardener.extensions[k].admission_controller_name ) ? s k :s] :[] ) ))
 
 infrastructures: (( &temporary ( uniq( sum[.landscape.iaas|[]|s,e|-> s e.type ( e.seeds.[*].type || ~ ) ] ) ) ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -7,7 +7,7 @@ utilities: (( &temporary ))
 plugins:
   - kubectl
   - (( ( length(.admissionControllers) > 0 ) -and ( .landscape.gardener.network-policies.active == true ) ? { "kubectl" = "kubectl_admission_netpols" } :~~ )) # network policies for admission controllers
-  - <<: (( length(.admissionControllers) > 0 ? sum[.admissionControllers|[]|s,n|-> *.admission.plugin_template] :~ )) # admission controllers
+  - <<: (( length(.admissionControllers) > 0 ? sum[.admissionControllers|[]|s,n|-> s *.admission.plugin_template] :~ )) # admission controllers
   - shoot-check
 
 shoot-check:
@@ -88,20 +88,20 @@ rendered_admission_templates:
 admission:
   <<: (( &temporary ))
 
-  fullName: (( |n|-> "gardener-extension-admission-" n ))
+  fullName: (( |n|-> .landscape.versions.gardener.extensions[n].admission_controller_name ))
 
   # virtual cluster deployment
   helm_template_virtual:
     <<: (( &template ))
     kubeconfig: (( .imports.kube_apiserver.export.kubeconfig ))
-    source: (( "extensions." n "/repo/charts/" admission.fullName(n) "/charts/application" ))
+    source: (( "extensions." n "/repo/charts/" name "/charts/application" ))
     name: (( admission.fullName(n) ))
     namespace: (( .landscape.namespace ))
     values: (( *admission.values_template ))
   helm_template_runtime:
     <<: (( &template ))
     kubeconfig: (( .landscape.clusters.[0].kubeconfig ))
-    source: (( "extensions." n "/repo/charts/" admission.fullName(n) "/charts/runtime" ))
+    source: (( "extensions." n "/repo/charts/" name "/charts/runtime" ))
     name: (( admission.fullName(n) ))
     namespace: (( .landscape.namespace ))
     values: (( *admission.values_template ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -286,50 +286,6 @@ extension_specs:
       primary: true
 
 ########################################
-  dns-external:
-########################################
-    <<: (( &template ))
-    extensionName: dns-external
-    type: helm
-    providerConfig:
-      chart: (( encoded_chart ))
-      values:
-        <<: (( valuesOverwrite ))
-        createCRDs: false
-        fullnameOverride: seed-dns-controller-manager
-        image:
-          repository: (( version.image_repo || ~~ ))
-          tag: (( version.image_tag || ~~ ))
-        configuration:
-          poolSize: 20
-          controllers: dnscontrollers
-          identifier: ""
-          serverPortHttp: 8080
-          ttl: (( .landscape.defaultTTL ))
-    resources:
-    - kind: DNSProvider
-      type: aws-route53
-      primary: true
-    - kind: DNSProvider
-      type: alicloud-dns
-      primary: true
-    - kind: DNSProvider
-      type: azure-dns
-      primary: true
-    - kind: DNSProvider
-      type: google-clouddns
-      primary: true
-    - kind: DNSProvider
-      type: openstack-designate
-      primary: true
-    - kind: DNSProvider
-      type: cloudflare-dns
-      primary: true
-    - kind: DNSProvider
-      type: infoblox-dns
-      primary: true
-
-########################################
   provider-aws:
 ########################################
     <<: (( &template ))
@@ -615,6 +571,18 @@ extension_specs:
         image:
           repository: (( version.image_repo || ~~ ))
           tag: (( version.image_tag || ~~ ))
+        dnsControllerManager:
+          image:
+            repository: (( version.dns-controller-manager.image_repo || ~~ ))
+            tag: (( version.dns-controller-manager.image_tag || ~~ ))
+          configuration:
+            cacheTtl: 300
+            controllers: dnscontrollers
+            dnsPoolResyncPeriod: 30m
+            serverPortHttp: 8080
+          createCRDs: false
+          deploy: true
+          replicaCount: 1
     resources:
     - kind: Extension
       type: shoot-dns-service

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -44,8 +44,8 @@ spec:
   KeyCert: (( |cert|->{$crt=cert.value.cert, $key=cert.value.key} ))
 
   new:
-    service_account_key: (( &template(x509genkey()) ))
-    static_token:          (( &template(exec( "bash", "-c", "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 128 | head -n 1" )) ))
+    service_account_key: (( &template( x509genkey() ) ))
+    static_token: (( &template( rand("[:alnum:]", 128) ) ))
 
   server:
     commonName: "garden:server:kube-apiserver"

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -6,10 +6,6 @@
         "version": "v1.54.1"
       },
       "extensions": {
-        "dns-external": {
-          "repo": "https://github.com/gardener/external-dns-management.git",
-          "version": "v0.13.2"
-        },
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
           "version": "v1.26.0"
@@ -83,6 +79,10 @@
           "version": "v0.21.0"
         }
       }
+    },
+    "dns-controller-manager": {
+      "repo": "https://github.com/gardener/external-dns-management.git",
+      "version": "v0.13.2"
     }
   }
 }

--- a/docs/extended/gardener.md
+++ b/docs/extended/gardener.md
@@ -21,7 +21,7 @@ While garden-setup automatically decides which Gardener extensions to deploy, it
 
 Some extensions come with admission controllers which can be deployed into the base cluster optionally. For chosen extensions, garden-setup is able to deploy the admission controller. To do this, it needs to be activated manually by setting `landscape.gardener.<extension_name>.admissionController` to `true`.
 
-Currently, this feature is only enabled for the `shoot-dns-service` extension.
+Currently, this feature can be used for the provider extensions (except vsphere) as well as the `networking-calico` and `shoot-dns-service` extensions.
 
 #### valueOverwrites for Extensions
 
@@ -30,7 +30,6 @@ Some values are set by default (take a look in the [deployment.yaml](../../compo
 
 The following extensions are available in `landscape.gardener.extensions`:
 
-- dns-external: [values.yaml](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/charts/gardener-extension-shoot-dns-service/values.yaml)
 - os-ubuntu: [values.yaml](https://github.com/gardener/gardener-extension-os-ubuntu/blob/master/charts/gardener-extension-os-ubuntu/values.yaml)
 - os-gardenlinux: [values.yaml](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/master/charts/gardener-extension-os-gardenlinux/values.yaml)
 - os-suse-chost: [values.yaml](https://github.com/gardener/gardener-extension-os-suse-chost/blob/master/charts/gardener-extension-os-suse-chost/values.yaml)
@@ -39,8 +38,11 @@ The following extensions are available in `landscape.gardener.extensions`:
 - provider-gcp: [values.yaml](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/charts/gardener-extension-provider-gcp/values.yaml)
 - provider-azure: [values.yaml](https://github.com/gardener/gardener-extension-provider-azure/blob/master/charts/gardener-extension-provider-azure/values.yaml)
 - provider-openstack: [values.yaml](https://github.com/gardener/gardener-extension-provider-openstack/blob/master/charts/gardener-extension-provider-openstack/values.yaml)
+- provider-alicloud: [values.yaml](https://github.com/gardener/gardener-extension-provider-alicloud/blob/master/charts/gardener-extension-provider-alicloud/values.yaml)
+- provider-vsphere: [values.yaml](https://github.com/gardener/gardener-extension-provider-vsphere/blob/master/charts/gardener-extension-provider-vsphere/values.yaml)
 - networking-calico: [values.yaml](https://github.com/gardener/gardener-extension-networking-calico/blob/master/charts/gardener-extension-networking-calico/values.yaml)
 - shoot-cert-service: [values.yaml](https://github.com/gardener/gardener-extension-shoot-cert-service/blob/master/charts/gardener-extension-shoot-cert-service/values.yaml)
+- shoot-dns-service: [values.yaml](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/charts/gardener-extension-shoot-dns-service/values.yaml)
 
 Example to set the `imageVectorOverwrite` (see [values.yaml](https://github.com/gardener/gardener-extension-networking-calico/blob/master/charts/gardener-extension-networking-calico/values.yaml#L14-L26)) for `gardener-extension-networking-calico`:
 


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Apart from the `shoot-dns-service` extension, admission controllers can now also be activated for the provider extensions (except vsphere) and the `networking-calico` extension. See the [documentation](docs/extended/gardener.md#admission-controllers) for further information.
```
```bugfix operator
Fixed a bug in the generation of the healthcheck token in the `kube-apiserver` component which could lead to garden-setup being stuck in some environments.
```
```breaking operator
The `dns-external` extension is not used by Gardener anymore and has been removed. Note that its functionality is not lost, but is partly implemented in Gardener directly and partly moved to the `shoot-dns-service` extension.
```
