### PR TITLE
Shoot DNS Service: Enable DNSProvider management

### DIFF
--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -583,6 +583,8 @@ extension_specs:
           createCRDs: false
           deploy: true
           replicaCount: 1
+        dnsProviderManagement:
+          enabled: true
     resources:
     - kind: Extension
       type: shoot-dns-service


### PR DESCRIPTION
**What this PR does / why we need it**:
If the shoot-dns-service is enabled, it should normally enable the DNSProvider management.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Shoot DNS Service: Enable DNSProvider management
```
