### PR TITLE
Upgrade apiserver, Gardener, and extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -27,7 +27,7 @@ landscape:
   versions:
     kube-apiserver:
       image_repo: k8s.gcr.io/kube-apiserver
-      image_tag: v1.20.15
+      image_tag: v1.21.14
     kube-controller-manager:
       image_repo: k8s.gcr.io/kube-controller-manager
       image_tag: (( kube-apiserver.image_tag ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.24.0"
+          "version": "v1.25.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.39.0"
+          "version": "v1.39.1"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.30.0"
+          "version": "v1.31.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.38.2"
+          "version": "v1.39.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.61.1"
+        "version": "1.61.2"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -56,7 +56,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.19.0"
+          "version": "v0.21.0"
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.61.0"
+        "version": "1.61.1"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.25.0"
+          "version": "v1.26.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.55.1"
+        "version": "v1.56.1"
       },
       "extensions": {
         "networking-calico": {


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade virtual cluster's apiserver to `v1.21.14`
```
```feature operator
Upgrade Gardener to `v1.56.1`
```
```other operator
Upgrade Gardener dashboard to `1.61.2`
```
```breaking operator
The new Gardener version uses the `PodDisruptionBudget` resource in version `v1`, which requires the base cluster to be at k8s `v1.21` or higher.
```
```other operator
Upgrade Gardener extension provider-aws to `v1.39.1`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.25.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.31.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.26.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.21.0`
```
