### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -27,7 +27,7 @@ landscape:
   versions:
     kube-apiserver:
       image_repo: k8s.gcr.io/kube-apiserver
-      image_tag: v1.21.14
+      image_tag: v1.22.15
     kube-controller-manager:
       image_repo: k8s.gcr.io/kube-controller-manager
       image_tag: (( kube-apiserver.image_tag ))

--- a/acre.yaml
+++ b/acre.yaml
@@ -27,7 +27,7 @@ landscape:
   versions:
     kube-apiserver:
       image_repo: k8s.gcr.io/kube-apiserver
-      image_tag: v1.22.15
+      image_tag: v1.23.13
     kube-controller-manager:
       image_repo: k8s.gcr.io/kube-controller-manager
       image_tag: (( kube-apiserver.image_tag ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -42,47 +42,48 @@ dashboard:
   name: "dashboard"
   namespace: (( .landscape.namespace ))
   values:
-    apiServerUrl: (( imports.kube_apiserver.export.apiserver_url ))
-    apiServerCa: (( imports.kube_apiserver.export.kube_apiserver_ca.cert ))
-    sessionSecret: (( rand("[:alnum:]", 30) ))
-    ingress:
-      tls:
-        secretName: (( imports.cert.export.certificate.secret_name ))
-      hosts:
-        - (( imports.identity.export.dashboard_dns ))
-        - (( .landscape.dashboard.cname.domain || ~~ ))
-      annotations:
-        <<: (( .landscape.dashboard.ingress.annotations || ~~ ))
-    image:
-      repository: (( .dashboard_version.image_repo || ~~ ))
-      tag: (( .dashboard_version.image_tag || ~~ ))
-      pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
-    oidc:
-      issuerUrl: (( imports.identity.export.issuer_url ))
-      ca: (( imports.cert-controller.export.ca.crt || ~~ ))
-      clientSecret: (( imports.identity.export.dashboardClientSecret ))
-      public:
-        clientId: kube-kubectl
-        clientSecret: (( imports.identity.export.kubectlClientSecret ))
-    kubeconfig: (( format( "((!!! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
-    podLabels:
-      <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))
-      networking.gardener.cloud/to-dns: allowed
-      networking.gardener.cloud/to-garden-kube-apiserver: allowed
-      networking.gardener.cloud/to-identity: allowed
-      networking.gardener.cloud/to-ingress: allowed
-      networking.gardener.cloud/to-world: allowed
-      networking.gardener.cloud/to-inside: allowed
-    gitHub: (( .landscape.dashboard.gitHub || ~~ ))
-    frontendConfig:
-      <<: (( .landscape.dashboard.frontendConfig || ~ ))
-      seedCandidateDeterminationStrategy: (( .imports.gardener_virtual.export.gardener.seedCandidateDeterminationStrategy ))
-      features:
-        <<: (( .landscape.dashboard.frontendConfig.features || ~ ))
-        terminalEnabled: (( ( .landscape.dashboard.terminals.active || false ) ))
-    terminal: (( ( .landscape.dashboard.terminals.active || false ) ? *.terminal_config :~~ ))
-    resources:
-      <<: (( .landscape.dashboard.resources || ~~ ))
+    global:
+      apiServerUrl: (( imports.kube_apiserver.export.apiserver_url ))
+      apiServerCa: (( imports.kube_apiserver.export.kube_apiserver_ca.cert ))
+      sessionSecret: (( rand("[:alnum:]", 30) ))
+      ingress:
+        tls:
+          secretName: (( imports.cert.export.certificate.secret_name ))
+        hosts:
+          - (( imports.identity.export.dashboard_dns ))
+          - (( .landscape.dashboard.cname.domain || ~~ ))
+        annotations:
+          <<: (( .landscape.dashboard.ingress.annotations || ~~ ))
+      image:
+        repository: (( .dashboard_version.image_repo || ~~ ))
+        tag: (( .dashboard_version.image_tag || ~~ ))
+        pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
+      oidc:
+        issuerUrl: (( imports.identity.export.issuer_url ))
+        ca: (( imports.cert-controller.export.ca.crt || ~~ ))
+        clientSecret: (( imports.identity.export.dashboardClientSecret ))
+        public:
+          clientId: kube-kubectl
+          clientSecret: (( imports.identity.export.kubectlClientSecret ))
+      kubeconfig: (( format( "((!!! asyaml( merge( read( \"%s/export/kube-apiserver/kubeconfig_internal_merge_snippet\", \"yaml\" ), read( \"%s/kubectl_sa/sa_%s.kubeconfig\" , \"yaml\") ) ) ))", env.ROOTDIR, env.GENDIR, .settings.serviceaccount_name ) ))
+      podLabels:
+        <<: (( ( .landscape.gardener.network-policies.active || false ) ? ~ :~~ ))
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-garden-kube-apiserver: allowed
+        networking.gardener.cloud/to-identity: allowed
+        networking.gardener.cloud/to-ingress: allowed
+        networking.gardener.cloud/to-world: allowed
+        networking.gardener.cloud/to-inside: allowed
+      gitHub: (( .landscape.dashboard.gitHub || ~~ ))
+      frontendConfig:
+        <<: (( .landscape.dashboard.frontendConfig || ~ ))
+        seedCandidateDeterminationStrategy: (( .imports.gardener_virtual.export.gardener.seedCandidateDeterminationStrategy ))
+        features:
+          <<: (( .landscape.dashboard.frontendConfig.features || ~ ))
+          terminalEnabled: (( ( .landscape.dashboard.terminals.active || false ) ))
+      terminal: (( ( .landscape.dashboard.terminals.active || false ) ? *.terminal_config :~~ ))
+      resources:
+        <<: (( .landscape.dashboard.resources || ~~ ))
 
 terminal_config:
   <<: (( &temporary &template ))

--- a/components/gardener/extensions/component.yaml
+++ b/components/gardener/extensions/component.yaml
@@ -26,8 +26,7 @@ spec_template:
   branch: (( version.branch || ~~ ))
   commit: (( version.commit || ~~ ))
   files:
-    - (( version.chart_path ))
-    - (( contains( deployment.admissionControllers, n ) ? ( "charts/" version.admission_controller_name ) :~~ ))
+    - charts
 
 deployment:
   # which extensions should be deployed

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -174,7 +174,7 @@ gardener:
             qps: 100
             burst: 130
           server:
-            https:
+            webhooks:
               bindAddress: 0.0.0.0
               port: 2719
               tls:

--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -122,7 +122,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/service_account.key
         - --tls-cert-file=/srv/kubernetes/apiserver/tls.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/tls.key
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         - --v=2
         livenessProbe:
           httpGet:
@@ -203,8 +203,8 @@ spec:
           failureThreshold: 2
           httpGet:
             path: /healthz
-            port: 10252
-            scheme: HTTP
+            port: 10257
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.56.1"
+        "version": "v1.57.1"
       },
       "extensions": {
         "networking-calico": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.18.0"
+          "version": "v1.19.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -76,7 +76,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.21.0"
+          "version": "v0.22.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -20,7 +20,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.18.0"
+          "version": "v1.19.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
-          "version": "v0.14.0"
+          "version": "v0.15.0"
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.61.2"
+        "version": "1.62.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.26.0"
+          "version": "v1.27.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -82,7 +82,7 @@
     },
     "dns-controller-manager": {
       "repo": "https://github.com/gardener/external-dns-management.git",
-      "version": "v0.13.3"
+      "version": "v0.14.1"
     }
   }
 }


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade virtual cluster to `v1.23.13`
```
```feature operator
Upgrade Gardener to `v1.57.1`
```
```feature operator
Upgrade Gardener dashboard to `1.62.0`
```
```other operator
Upgrade Gardener extension os-ubuntu to `v1.19.0`
```
```other operator
Upgrade Gardener extension os-gardenlinux to `v0.15.0`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.19.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.27.0`
```
```other operator
Upgrade Gardener terminal-controller-manager to `v0.22.0`
```
```other operator
Upgrade Gardener external-dns-management to `v0.14.1`
```
```bugfix operator
The `sow convertkubeconfig` command should now also work for base clusters running k8s v1.24 or higher.
```
