### PR TITLE
Upgrade Gardener to v1.58.3

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.57.1"
+        "version": "v1.58.3"
       },
       "extensions": {
         "networking-calico": {


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.58.3`
```
