### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -143,104 +143,102 @@ gardenletBootstrapKubeconfig:
       token: (( configValues.bootstrapToken.id "." configValues.bootstrapToken.secret ))
 
 gardenletSpec:
-  global:
-    gardenlet:
+  enabled: true
+  replicaCount: 1
+  serviceAccountName: gardenlet
+  image:
+    repository: (( .landscape.versions.gardener.gardenlet.image_repo ))
+    tag: (( .landscape.versions.gardener.gardenlet.image_tag ))
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 750m
+      memory: 512Mi
+  additionalVolumes: []
+  additionalVolumeMounts: []
+  env: []
+  vpa: false
+  imageVectorOverwrite: (( asyaml( configValues.imageVectorOverwrites.imageVectorOverwrite ) || ~~ ))
+  componentImageVectorOverwrites: (( asyaml( configValues.imageVectorOverwrites.componentImageVectorOverwrite ) || ~~ ))
+  config:
+    gardenClientConnection:
+      acceptContentTypes: application/json
+      contentType: application/json
+      qps: (( configValues.config.gardenClientConnection.qps || 100 ))
+      burst: (( configValues.config.gardenClientConnection.burst || 130 ))
+      gardenClusterAddress: (( .imports.kube_apiserver.export.apiserver_url ))
+      gardenClusterCACert: (( base64( .imports.kube_apiserver.export.kube_apiserver_ca.cert ) ))
+      bootstrapKubeconfig:
+        name: gardenlet-kubeconfig-bootstrap
+        namespace: garden
+        kubeconfig: (( asyaml( gardenletBootstrapKubeconfig ) ))
+      kubeconfigSecret:
+        name: gardenlet-kubeconfig
+        namespace: garden
+    seedClientConnection:
+      acceptContentTypes: application/json
+      contentType: application/json
+      qps: (( configValues.config.seedClientConnection.qps || 25 ))
+      burst: (( configValues.config.seedClientConnection.burst || 50 ))
+    shootClientConnection:
+      acceptContentTypes: application/json
+      contentType: application/json
+      qps: (( configValues.config.shootClientConnection.qps || 25 ))
+      burst: (( configValues.config.shootClientConnection.burst || 50 ))
+    controllers:
+      backupBucket:
+        concurrentSyncs: 20
+      backupEntry:
+        concurrentSyncs: 20
+        deletionGracePeriodHours: 0
+      seed:
+        concurrentSyncs: 5
+        syncPeriod: 1m
+        heartBeatPeriod: 20s
+        reserveExcessCapacity: true
+      shoot:
+        concurrentSyncs: 20
+        syncPeriod: 1h
+        retryDuration: 24h
+        respectSyncPeriodOverwrite: false
+        reconcileInMaintenanceOnly: false
+      shootCare:
+        concurrentSyncs: 5
+        syncPeriod: 30s
+        conditionThresholds:
+        - type: APIServerAvailable
+          duration: 1m
+        - type: ControlPlaneHealthy
+          duration: 1m
+        - type: SystemComponentsHealthy
+          duration: 1m
+        - type: EveryNodeReady
+          duration: 5m
+    leaderElection:
+      leaderElect: true
+      leaseDuration: 15s
+      renewDeadline: 10s
+      retryPeriod: 2s
+      resourceLock: configmapsleases
+    logLevel: info
+    logging:
+      <<: (( configValues.config.logging || ~~ ))
+    kubernetesLogLevel: 0
+    featureGates: 
+      <<: (( configValues.config.featureGates || {} ))
+      ManagedIstio: (( pluginSpecs.managedIstioActive ))
+      APIServerSNI: (( configValues.config.featureGates.APIServerSNI || true ))
+    seedConfig:
+      metadata:
+        name: (( configValues.name ))
+      spec: (( seedSpec ))
+    monitoring: (( defined(configValues.monitoring.remoteWrite) ? monitoringTemplate :~~ ))
+  # Deployment related configuration
+  deployment:
+    virtualGarden:
       enabled: true
-      replicaCount: 1
-      serviceAccountName: gardenlet
-      image:
-        repository: (( .landscape.versions.gardener.gardenlet.image_repo ))
-        tag: (( .landscape.versions.gardener.gardenlet.image_tag ))
-      resources:
-        requests:
-          cpu: 100m
-          memory: 100Mi
-        limits:
-          cpu: 750m
-          memory: 512Mi
-      additionalVolumes: []
-      additionalVolumeMounts: []
-      env: []
-      vpa: false
-      imageVectorOverwrite: (( asyaml( configValues.imageVectorOverwrites.imageVectorOverwrite ) || ~~ ))
-      componentImageVectorOverwrites: (( asyaml( configValues.imageVectorOverwrites.componentImageVectorOverwrite ) || ~~ ))
-      config:
-        gardenClientConnection:
-          acceptContentTypes: application/json
-          contentType: application/json
-          qps: (( configValues.config.gardenClientConnection.qps || 100 ))
-          burst: (( configValues.config.gardenClientConnection.burst || 130 ))
-          gardenClusterAddress: (( .imports.kube_apiserver.export.apiserver_url ))
-          gardenClusterCACert: (( base64( .imports.kube_apiserver.export.kube_apiserver_ca.cert ) ))
-          bootstrapKubeconfig:
-            name: gardenlet-kubeconfig-bootstrap
-            namespace: garden
-            kubeconfig: (( asyaml( gardenletBootstrapKubeconfig ) ))
-          kubeconfigSecret:
-            name: gardenlet-kubeconfig
-            namespace: garden
-        seedClientConnection:
-          acceptContentTypes: application/json
-          contentType: application/json
-          qps: (( configValues.config.seedClientConnection.qps || 25 ))
-          burst: (( configValues.config.seedClientConnection.burst || 50 ))
-        shootClientConnection:
-          acceptContentTypes: application/json
-          contentType: application/json
-          qps: (( configValues.config.shootClientConnection.qps || 25 ))
-          burst: (( configValues.config.shootClientConnection.burst || 50 ))
-        controllers:
-          backupBucket:
-            concurrentSyncs: 20
-          backupEntry:
-            concurrentSyncs: 20
-            deletionGracePeriodHours: 0
-          seed:
-            concurrentSyncs: 5
-            syncPeriod: 1m
-            heartBeatPeriod: 20s
-            reserveExcessCapacity: true
-          shoot:
-            concurrentSyncs: 20
-            syncPeriod: 1h
-            retryDuration: 24h
-            respectSyncPeriodOverwrite: false
-            reconcileInMaintenanceOnly: false
-          shootCare:
-            concurrentSyncs: 5
-            syncPeriod: 30s
-            conditionThresholds:
-            - type: APIServerAvailable
-              duration: 1m
-            - type: ControlPlaneHealthy
-              duration: 1m
-            - type: SystemComponentsHealthy
-              duration: 1m
-            - type: EveryNodeReady
-              duration: 5m
-        leaderElection:
-          leaderElect: true
-          leaseDuration: 15s
-          renewDeadline: 10s
-          retryPeriod: 2s
-          resourceLock: configmapsleases
-        logLevel: info
-        logging:
-          <<: (( configValues.config.logging || ~~ ))
-        kubernetesLogLevel: 0
-        featureGates: 
-          <<: (( configValues.config.featureGates || {} ))
-          ManagedIstio: (( pluginSpecs.managedIstioActive ))
-          APIServerSNI: (( configValues.config.featureGates.APIServerSNI || true ))
-        seedConfig:
-          metadata:
-            name: (( configValues.name ))
-          spec: (( seedSpec ))
-        monitoring: (( defined(configValues.monitoring.remoteWrite) ? monitoringTemplate :~~ ))
-    # Deployment related configuration
-    deployment:
-      virtualGarden:
-        enabled: true
 
 monitoringTemplate:
   <<: (( &temporary ))
@@ -270,7 +268,7 @@ pluginSpecs:
     kubeconfig: (( configValues.kubeconfigs.seed ))
     files:
       - (( "renderedPluginSpecs[" id "].gardenlet/rendered_charts.yaml" ))
-    source: "git/repo/charts/gardener/gardenlet/charts/runtime"
+    source: "git/repo/charts/gardener/gardenlet"
     name: gardenlet
     namespace: garden
     values: (( gardenletSpec ))

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.39.1"
+          "version": "v1.40.3"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.58.3"
+        "version": "v1.59.2"
       },
       "extensions": {
         "networking-calico": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.27.0"
+          "version": "v1.27.1"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.31.0"
+          "version": "v1.32.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.62.0"
+        "version": "1.63.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.26.0"
+          "version": "v1.27.0"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.25.1"
+          "version": "v1.26.1"
         },
         "provider-alicloud": {
           "repo": "https://github.com/gardener/gardener-extension-provider-alicloud.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.25.0"
+          "version": "v1.26.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -56,7 +56,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.21.0"
+          "version": "v0.22.0"
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.29.0"
+          "version": "v1.30.3"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -60,7 +60,7 @@
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
-          "version": "v0.6.0"
+          "version": "v0.7.0"
         }
       }
     },


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.59.2`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.30.3`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.22.0`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.26.1`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.40.3`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.32.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.27.0`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.26.0`
```
```other operator
Upgrade Gardener extension runtime-gvisor to `v0.7.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.27.1`
```
```feature operator
Upgrade Gardener Dashboard to `1.63.0`
```