### PR TITLE
actually use etcd-events for events

### DIFF
--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -96,7 +96,7 @@ spec:
         - --etcd-servers={{ .Values.etcd.main.endpoints }}
         - --external-hostname={{ .Values.apiServer.externalHostname }}
 {{ if .Values.etcd.events.endpoints }}
-        - --etcd-servers-overrides=/events#{{ .Values.etcd.events.endpoints }}
+        - --etcd-servers-overrides=/events#{{ .Values.etcd.events.endpoints }},coordination.k8s.io/leases#{{ .Values.etcd.events.endpoints }}
 {{ end }}
         - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
         - --insecure-port=0

--- a/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/deployment-kube-apiserver.yaml
@@ -96,6 +96,7 @@ spec:
         - --etcd-servers={{ .Values.etcd.main.endpoints }}
         - --external-hostname={{ .Values.apiServer.externalHostname }}
 {{ if .Values.etcd.events.endpoints }}
+        - --etcd-servers-overrides=/events#{{ .Values.etcd.events.endpoints }}
 {{ end }}
         - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
         - --insecure-port=0


### PR DESCRIPTION
**What this PR does / why we need it**:
A second etcd named "etcd-events" gets deployed but apparently is not used. This change actually uses it to store the /events key space, which I assume had been the plan all the time. This will reduce backup size of busy gardeners.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
We just borrow this chart and use it outside of garden-setup, so maybe I'm just unaware of how etcd-events gets connected. Also I only tested this change outside of garden-setup.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Store kubernetes events in etcd-events-0 instead of etcd-main-0
```
