### PR TITLE
Upgrade Gardener and dashboard

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.59.2"
+        "version": "v1.60.3"
       },
       "extensions": {
         "networking-calico": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.63.0"
+        "version": "1.64.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.60.3`
```
```feature operator
Upgrade Gardener dashboard to `1.64.0`
```
```other operator
⚠️ There seems to be a race condition in version `v1.60.3` of Gardener which causes problems when deleting seeds. If you plan to deploy and quickly delete a landscape again, using the previous release of garden-setup is recommended. If you intend to keep the landscape for a longer time, upgrading your landscape later with a newer version of garden-setup is not officially supported, but will work most of the time anyway, so you can wait with deleting the landscape until the issue is fixed.
```
