### PR TITLE
Remove the use of the enableBasicAuthentication field

### DIFF
--- a/components/gardencontent/seeds/manifests/shoot_manifest.yaml
+++ b/components/gardencontent/seeds/manifests/shoot_manifest.yaml
@@ -22,7 +22,6 @@ spec:
       enabled: true
     kubeAPIServer:
       tmpBaseVersion: (( &temporary ( substr( values.values.k8sVersion, 0, 4 ) ) ))
-      enableBasicAuthentication: (( tmpBaseVersion == "1.14" -or tmpBaseVersion == "1.15" -or tmpBaseVersion == "1.16" -or tmpBaseVersion == "1.17" -or tmpBaseVersion == "1.18" ? true :false ))
     kubeControllerManager:
       horizontalPodAutoscaler:
         downscaleStabilization: 24h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the use of the enableBasicAuthentication field

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
