### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -61,6 +61,7 @@ dashboard:
       oidc:
         issuerUrl: (( imports.identity.export.issuer_url ))
         ca: (( imports.cert-controller.export.ca.crt || ~~ ))
+        clientId: "dashboard"
         clientSecret: (( imports.identity.export.dashboardClientSecret ))
         public:
           clientId: kube-kubectl

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.32.0"
+          "version": "v1.33.0"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -60,7 +60,7 @@
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
-          "version": "v0.7.0"
+          "version": "v0.8.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.27.0"
+          "version": "v1.28.1"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.60.3"
+        "version": "v1.61.5"
       },
       "extensions": {
         "networking-calico": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.27.1"
+          "version": "v1.28.0"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -82,7 +82,7 @@
     },
     "dns-controller-manager": {
       "repo": "https://github.com/gardener/external-dns-management.git",
-      "version": "v0.14.1"
+      "version": "v0.14.2"
     }
   }
 }

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -76,7 +76,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.22.0"
+          "version": "v0.23.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.40.3"
+          "version": "v1.41.0"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -56,7 +56,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.22.0"
+          "version": "v0.23.0"
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.64.0"
+        "version": "1.66.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.26.0"
+          "version": "v1.27.0"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.61.5`
```
```feature operator
Upgrade Gardener Dashboard to `1.66.0`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.28.0`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.33.0`
```
```other operator
Upgrade Gardener terminal-controller-manager to `v0.23.0`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.27.0`
```
```other operator
Upgrade Gardener extension runtime-gvisor to `v0.8.0`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.41.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.23.0`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.28.1`
```
```other operator
Upgrade Gardener DNS controller to `v0.14.2`
```

