### PR TITLE
upgrade Gardener dashboard to 1.67.0

### DIFF
--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -67,7 +67,7 @@
     "dashboard": {
       "core": {
         "repo": "https://github.com/gardener/dashboard.git",
-        "version": "1.66.1"
+        "version": "1.67.0"
       },
       "identity": {
         "repo": "(( dashboard.core.repo ))",


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener Dashboard to `1.67.0`
```
