### PR TITLE
use '--kube-version' flag for helm template

### DIFF
--- a/components/cert-manager/controller/component.yaml
+++ b/components/cert-manager/controller/component.yaml
@@ -4,6 +4,7 @@ component:
   imports:
     - dns-controller
     - namespace
+    - k8sversion
 
   stubs:
     - lib/templates/utilities.yaml

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -126,6 +126,8 @@ helm:
   source: "chart-checkout/charts/cert-manager"
   name: cert-manager
   namespace: (( .namespace.name ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     image:
       repository: (( .landscape.versions.cert-manager.controller.image_repo || ~~ ))

--- a/components/cert-manager/solver/component.yaml
+++ b/components/cert-manager/solver/component.yaml
@@ -4,6 +4,7 @@ component:
   imports:
     - dns-controller
     - cert-controller: cert-manager/controller
+    - k8sversion
 
   stubs: []
 

--- a/components/cert-manager/solver/deployment.yaml
+++ b/components/cert-manager/solver/deployment.yaml
@@ -21,6 +21,8 @@ helm:
   source: "git/repo/charts/certificate-dns-bridge"
   name: certificate-dns-bridge
   namespace: (( imports.cert-controller.export.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     groupName: (( imports.cert-controller.export.groupName ))
     solverName: (( imports.cert-controller.export.solverName ))

--- a/components/dashboard/component.yaml
+++ b/components/dashboard/component.yaml
@@ -24,6 +24,7 @@ component:
     - cert: cert-manager/cert
     - cert-controller: cert-manager/controller
     - dns-controller
+    - k8sversion
     - (( ( .landscape.gardener.network-policies.active || false ) ? "network-policies" :~~ ))
     - (( ( .landscape.dashboard.terminals.active || false ) ? "terminals" :~~ ))
 

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -41,6 +41,8 @@ dashboard:
   source: "git/repo/charts/gardener-dashboard"
   name: "dashboard"
   namespace: (( .landscape.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     global:
       apiServerUrl: (( imports.kube_apiserver.export.apiserver_url ))

--- a/components/dns-controller/component.yaml
+++ b/components/dns-controller/component.yaml
@@ -15,6 +15,9 @@
 ---
 landscape: (( &temporary ))
 component:
+  imports:
+  - k8sversion
+
   stubs:
     - plugins/kubectl/utilities.yaml
 

--- a/components/dns-controller/deployment.yaml
+++ b/components/dns-controller/deployment.yaml
@@ -42,6 +42,8 @@ helm:
   source: "git/repo/charts/external-dns-management"
   name: (( settings.fullname ))
   namespace: (( .spec.common.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values: (( .spec.helm ))
 
 kubectl:

--- a/components/etcd/cluster/component.yaml
+++ b/components/etcd/cluster/component.yaml
@@ -19,6 +19,7 @@ component:
   imports:
     - (( landscape.etcd.backup.active ? { "backupinfra" = "etcd/backupinfra" } :~~ ))
     - namespace
+    - k8sversion
 
   stubs:
     - lib/templates/utilities.yaml

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -81,6 +81,8 @@ etcd:
     source: chart
     name: garden-etcd-main
     namespace: (( .landscape.namespace ))
+    flags:
+      deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
     values:
       name: (( main.name ))
       replicas: 1
@@ -121,6 +123,8 @@ etcd:
     source: chart
     name: garden-etcd-events
     namespace: (( .landscape.namespace ))
+    flags:
+      deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
     values:
       name: (( events.name ))
       replicas: 1

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -258,6 +258,8 @@ pluginSpecs:
     source: "git/repo/charts/gardener/gardenlet"
     name: gardenlet
     namespace: garden
+    flags:
+      deploy: (( "--kube-version=" configValues.k8sVersion ))
     values: (( gardenletSpec ))
   seedReady:
     kubeconfig: (( configValues.kubeconfigs.virtual ))

--- a/components/gardencontent/seeds/seeds/deployment.yaml
+++ b/components/gardencontent/seeds/seeds/deployment.yaml
@@ -64,3 +64,6 @@ providerconfig:
     shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
     settings: (( v.seedSettings || ~~ ))
   secretname: (( name "-" v.mode ))
+  cloudprofile: (( v.cloudprofile || v.name ))
+  k8sVersion: (( .imports.shoots.export.shoots[v.name].k8sVersion ))
+

--- a/components/gardencontent/seeds/shoots/deployment.yaml
+++ b/components/gardencontent/seeds/shoots/deployment.yaml
@@ -65,5 +65,6 @@ shoot_template:
   <<: (( &template &temporary ))
   name: (( e.metadata.name ))
   namespace: (( e.metadata.namespace ))
+  k8sVersion: (( e.spec.kubernetes.version ))
 
 shoots: (( sum[.kubectl.[*].manifests[0]|[]|s,e|-> s *.shoot_template] ))

--- a/components/gardencontent/seeds/soils/component.yaml
+++ b/components/gardencontent/seeds/soils/component.yaml
@@ -22,6 +22,7 @@ component:
     - gardener_runtime: gardener/extensions
     - ingress_dns: ingress-controller
     - kube_apiserver: kube-apiserver
+    - k8sversion
 
   stubs:
     - plugins/kubectl/utilities.yaml

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -76,5 +76,6 @@ providerconfig:
     settings: (( v.seedSettings || ~~ ))
   secretname: (( name "-" v.mode ))
   monitoring: (( landscape.monitoring ))
+  k8sVersion: (( .imports.k8sversion.export.k8sVersions.soils[v.name] ))
 
 renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/components/gardener/extensions/deployment.yaml
+++ b/components/gardener/extensions/deployment.yaml
@@ -97,6 +97,8 @@ admission:
     source: (( "extensions." n "/repo/charts/" name "/charts/application" ))
     name: (( admission.fullName(n) ))
     namespace: (( .landscape.namespace ))
+    flags:
+      deploy: (( "--kube-version=" .imports.kube_apiserver.export.k8sVersion ))
     values: (( *admission.values_template ))
   helm_template_runtime:
     <<: (( &template ))

--- a/components/gardener/runtime/component.yaml
+++ b/components/gardener/runtime/component.yaml
@@ -19,6 +19,7 @@ component:
     - gardener_virtual: gardener/virtual
     - kube_apiserver: "kube-apiserver"
     - namespace
+    - k8sversion
 
   stubs:
     - plugins/kubectl/utilities.yaml

--- a/components/gardener/runtime/deployment.yaml
+++ b/components/gardener/runtime/deployment.yaml
@@ -82,6 +82,8 @@ gardener:
   values: (( merge(.imports.gardener_virtual.export.gardener.values, spec) ))
   name: gardener
   namespace: (( landscape.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   spec:
     global:
       apiserver:

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -128,6 +128,8 @@ gardener:
   source: "git/repo/charts/gardener/controlplane/charts/application"
   name: "gardener"
   namespace: "garden"
+  flags:
+    deploy: (( "--kube-version=" .imports.kube_apiserver.export.k8sVersion ))
   values:
     global:
       apiserver:

--- a/components/identity/component.yaml
+++ b/components/identity/component.yaml
@@ -19,6 +19,7 @@ component:
     - ingress-controller
     - namespace
     - cert: cert-manager/cert
+    - k8sversion
 
   stubs:
     - lib/templates/utilities.yaml

--- a/components/identity/deployment.yaml
+++ b/components/identity/deployment.yaml
@@ -64,6 +64,8 @@ identity:
   source: "git/repo/charts/identity"
   name: "identity"
   namespace: (( .landscape.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     image:
       repository: (( .identity_version.image_repo || ~~ ))

--- a/components/ingress-controller/component.yaml
+++ b/components/ingress-controller/component.yaml
@@ -17,6 +17,7 @@ landscape: (( &temporary ))
 component:
   imports:
     - dns-controller
+    - k8sversion
   
   plugins:
     - git

--- a/components/ingress-controller/deployment.yaml
+++ b/components/ingress-controller/deployment.yaml
@@ -34,7 +34,7 @@ ingresscontroller:
   name: "nginx-ingress"
   namespace: "kube-system"
   flags:
-    deploy: "--kube-version=1.20.0"
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     fullnameOverride: (( .ingresscontroller.name ))
     controller:

--- a/components/k8sversion/component.yaml
+++ b/components/k8sversion/component.yaml
@@ -1,0 +1,16 @@
+# Copyright 2023 Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+component:

--- a/components/k8sversion/deployment.yaml
+++ b/components/k8sversion/deployment.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+landscape: (( &temporary ))
+env: (( &temporary ))
+
+commands:
+  <<: (( &temporary ))
+  get_k8s_version: (( |kcfg_path|-> ("raw_version" = .commands.get_raw_version(kcfg_path)) raw_version.serverVersion.major "." raw_version.serverVersion.minor ))
+  get_raw_version: (( |kcfg_path|-> exec(["kubectl", "--kubeconfig", kcfg_path, "version", "-o", "yaml"]) ))
+
+iaasSeedsSoils: (( &temporary ( select[.landscape.iaas|elem|-> elem.mode == "seed" -or elem.mode == "soil"] ) ))
+
+k8sVersions:
+  base: (( soils[.landscape.iaas[0].name] ))
+  soils: (( sum[.iaasSeedsSoils|{}|s,elem|-> s { elem.name = .commands.get_k8s_version(valid(elem.cluster.kubeconfig) ? tempfile(asyaml(elem.cluster.kubeconfig)) :join("/", env.ROOTDIR, .landscape.clusters[0].kubeconfig)) }] ))

--- a/components/k8sversion/export.yaml
+++ b/components/k8sversion/export.yaml
@@ -1,0 +1,19 @@
+# Copyright 2023 Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+k8sVersions: (( &temporary ))
+
+export:
+  k8sVersions: (( .k8sVersions ))

--- a/components/kube-apiserver/component.yaml
+++ b/components/kube-apiserver/component.yaml
@@ -22,6 +22,7 @@ component:
     - namespace
     - (( ( .landscape.gardener.network-policies.active || false ) ? "network-policies" :~~ ))
     - cert-controller: cert-manager/controller
+    - k8sversion
 
   stubs:
     - lib/templates/utilities.yaml

--- a/components/kube-apiserver/deployment.yaml
+++ b/components/kube-apiserver/deployment.yaml
@@ -104,6 +104,8 @@ kubeapiserver:
   name: "garden-kube-apiserver"
   namespace: (( .landscape.namespace ))
   serviceName: (( name ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     images:
       apiserver: (( .landscape.versions.kube-apiserver.image_repo ":" .landscape.versions.kube-apiserver.image_tag ))

--- a/components/kube-apiserver/export.yaml
+++ b/components/kube-apiserver/export.yaml
@@ -20,7 +20,7 @@ env: (( &temporary ))
 
 temp:
   <<: (( &temporary ))
-  command:
+  get_kubeconfig_command:
     - kubectl
     - --kubeconfig
     - (( lookup_file(landscape.clusters.[0].kubeconfig, env.ROOTDIR).[0] ))
@@ -31,6 +31,13 @@ temp:
     - garden-kubeconfig-for-admin
     - "-o"
     - "jsonpath={.data.kubeconfig}"
+  get_k8s_version_command:
+    - kubectl
+    - --kubeconfig
+    - (( tempfile(asyaml(export.kubeconfig)) ))
+    - version
+    - -o
+    - yaml
 
 export:
   gardener_dns: (( .settings.gardener_dns ))
@@ -38,8 +45,9 @@ export:
   apiserver_url: (( "https://" apiserver_dns ))
   apiserver_url_internal: (( .settings.apiserver_url_internal ))
   kube_apiserver_ca: (( .state.kube_apiserver_ca.value ))
-  kubeconfig: (( parse(base64_decode(exec( temp.command ))) || "" ))
+  kubeconfig: (( parse(base64_decode(exec( temp.get_kubeconfig_command ))) || "" ))
   kubeconfig_internal_merge_snippet: (( .files.kubeconfig_internal_merge_snippet.data ))
+  k8sVersion: (( ( "raw_version" = exec( temp.get_k8s_version_command ) ) raw_version.serverVersion.major "." raw_version.serverVersion.minor ))
 
 files:
   kubeconfig:

--- a/components/kube-apiserver/export.yaml
+++ b/components/kube-apiserver/export.yaml
@@ -31,6 +31,17 @@ temp:
     - garden-kubeconfig-for-admin
     - "-o"
     - "jsonpath={.data.kubeconfig}"
+  get_apiserver_deployment_command:
+    - kubectl
+    - --kubeconfig
+    - (( lookup_file(landscape.clusters.[0].kubeconfig, env.ROOTDIR).[0] ))
+    - "-n"
+    - (( landscape.namespace ))
+    - get
+    - deployment
+    - garden-kube-apiserver
+    - "-o"
+    - "jsonpath={.status}"
   get_k8s_version_command:
     - kubectl
     - --kubeconfig
@@ -38,6 +49,7 @@ temp:
     - version
     - -o
     - yaml
+  wait_for_readiness_and_get_k8s_version: (( sync[exec_uncached( temp.get_apiserver_deployment_command )|s|-> defined(s.readyReplicas) -and s.readyReplicas == 3, .temp.get_k8s_version_command] )) # dirty hack to ensure the apiserver is ready before trying to fetch its version
 
 export:
   gardener_dns: (( .settings.gardener_dns ))
@@ -47,7 +59,7 @@ export:
   kube_apiserver_ca: (( .state.kube_apiserver_ca.value ))
   kubeconfig: (( parse(base64_decode(exec( temp.get_kubeconfig_command ))) || "" ))
   kubeconfig_internal_merge_snippet: (( .files.kubeconfig_internal_merge_snippet.data ))
-  k8sVersion: (( ( "raw_version" = exec( temp.get_k8s_version_command ) ) raw_version.serverVersion.major "." raw_version.serverVersion.minor ))
+  k8sVersion: (( ( "serverVersion" = sync[exec_uncached( temp.wait_for_readiness_and_get_k8s_version )|v|-> defined(v.serverVersion), v.serverVersion] ) serverVersion.major "." serverVersion.minor ))
 
 files:
   kubeconfig:

--- a/components/monitoring/gardener-metrics-exporter/component.yaml
+++ b/components/monitoring/gardener-metrics-exporter/component.yaml
@@ -7,6 +7,7 @@ component:
     - grafana: monitoring/grafana
     - kube-apiserver
     - namespace
+    - k8sversion
 
   plugins:
     - git

--- a/components/monitoring/gardener-metrics-exporter/deployment.yaml
+++ b/components/monitoring/gardener-metrics-exporter/deployment.yaml
@@ -71,6 +71,8 @@ helm:
   source: "git/repo/charts/gardener-metrics-exporter"
   name: gardener-metrics-exporter
   namespace: (( .landscape.namespace ))
+  flags:
+    deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
   values:
     image:
       repository: (( .landscape.versions.monitoring.gardener-metrics-exporter.image_repo || ~~ ))

--- a/components/terminals/component.yaml
+++ b/components/terminals/component.yaml
@@ -7,6 +7,7 @@ component:
     - ingress-controller
     - cert-manager/solver
     - gardener/runtime
+    - k8sversion
 
   plugins:
     - git

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -54,6 +54,8 @@ terminals:
     source: "git/repo/charts/terminal/charts/application"
     name: "terminals"
     namespace: (( .settings.namespace ))
+    flags:
+      deploy: (( "--kube-version=" .imports.kube-apiserver.export.k8sVersion ))
     values: (( common.values ))
   runtime:
     kubeconfig: (( landscape.clusters.[0].kubeconfig ))
@@ -62,6 +64,8 @@ terminals:
     source: "git/repo/charts/terminal/charts/runtime"
     name: "terminals"
     namespace: (( .settings.namespace ))
+    flags:
+      deploy: (( "--kube-version=" .imports.k8sversion.export.k8sVersions.base ))
     values: (( common.values ))
 
 kube-rbac-proxy:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `helm template` command takes an optional `--kube-version` flag, where the cluster's kubernetes version can be provided. This allows helm charts to differentiate between different k8s versions by using `.Capabilities.KubeVersion`.
With this PR, the `--kube-version` flag is provided to all `helm template` calls.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
garden-setup will now provide the cluster's version to `helm template` calls via the `--kube-version` flag. This has a few side effects:
- There is a new component called `k8sversion`. It's a dummy component, which doesn't actually deploy anything, but it fetches each pre-existing cluster's (= base cluster and potential soils) k8s version instead.
- After deployment of the virtual kube-apiserver, the export generation now waits until it is ready, so it can fetch its k8s version.
- ⚠️ Since helm might deploy different manifests for different k8s versions, this change means that the result of `sow deploy` now also depends on the k8s versions of all clusters in `landscape.iaas`.
  - Re-running `sow deploy` after upgrading the base cluster to a higher k8s version could therefore lead to changes.
  - This could be prevented by not re-running the `k8sversion` component, as that one is responsible for fetching the k8s versions. Most of the time, deploying the helm chart fitting to the cluster is probably desired, though.
```
