### PR TITLE
make s3 bucket private

### DIFF
--- a/components/etcd/backupinfra/provider/s3/main.tf
+++ b/components/etcd/backupinfra/provider/s3/main.tf
@@ -31,6 +31,15 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 //=====================================================================
 //= Output variables
 //=====================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:

s3 buckets created in the `etcd/backupinfra` component should now be private.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
S3 buckets created in the `etcd/backupinfra` component are now private.
```
