### PR TITLE
Upgrade Gardener and extensions

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -203,6 +203,15 @@ landscape:
       # to overwrite:
       # set image_repo here (mandatory)
       # set image_tag here (defaults to latest, if image_repo is set and image_tag is not given)
+    terminal-image:
+      container:
+        <<: (( merge ))
+        image_tag: 0.22.0
+        image_repo: eu.gcr.io/gardener-project/gardener/ops-toolbelt
+      containerOperator:
+        <<: (( merge ))
+        image_tag: (( container.image_tag ))
+        image_repo: (( container.image_repo ))
     dns-controller-manager:
       <<: (( merge ))
       tag: (( valid( branch ) -or valid( commit ) ? ~~ :.dependency_versions.versions.dns-controller-manager.version ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -89,9 +89,9 @@ dashboard:
 terminal_config:
   <<: (( &temporary &template ))
   container:
-    image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.9.0
+    image: (( .landscape.versions.terminal-image.container.image_repo ":" .landscape.versions.terminal-image.container.image_tag ))
   containerOperator:
-    image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.9.0
+    image: (( .landscape.versions.terminal-image.containerOperator.image_repo ":" .landscape.versions.terminal-image.containerOperator.image_tag ))
   containerImageDescriptions:
   - image: /eu.gcr.io/gardener-project/gardener/ops-toolbelt:.*/
     description: Run `ghelp` to get information about installed tools and packages

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -50,8 +50,7 @@ secretManifests:
     token-secret: (( configValues.bootstrapToken.secret ))
     usage-bootstrap-authentication: "true"
     usage-bootstrap-signing: "true"
-- <<: (( configValues.isBaseCluster ? ~~ :~ ))
-  apiVersion: v1
+- apiVersion: v1
   kind: Secret
   metadata:
     name: (( configValues.secretname "-ingress-dns-secret" ))
@@ -85,8 +84,16 @@ seedSpec:
     secretRef:
       name: (( configValues.secretname "-backup" ))
       namespace: (( configValues.namespace ))
-  dns: (( configValues.isBaseCluster ? ingressTemplate.baseCluster.dns :ingressTemplate.default.dns ))
-  ingress: (( configValues.isBaseCluster ? ~~ :ingressTemplate.default.ingress ))
+  dns:
+    provider:
+      type: (( configValues.dns.type ))
+      secretRef:
+        name: (( configValues.secretname "-ingress-dns-secret" ))
+        namespace: (( configValues.namespace ))
+  ingress:
+    domain: (( configValues.seed.ingressdomain ))
+    controller:
+      kind: nginx
   secretRef:
     name: (( configValues.secretname ))
     namespace: (( configValues.namespace ))
@@ -97,23 +104,6 @@ seedSpec:
     shootDefaults: (( configValues.seed.shootDefaultNetworks || configValues.config.type == "alicloud" ? { "pods" = "172.32.0.0/13", "services" = "172.40.0.0/13" } :{ "pods" = "100.96.0.0/11", "services" = "100.64.0.0/13" } ))
   taints: (( configValues.config.mode == "soil" ? [{ "key" = "seed.gardener.cloud/protected" }] :~~ ))
   settings: (( element( merge( seedSettingMergeTemplate, configValues.seed || {} ), "settings" ) ))
-
-ingressTemplate:
-  <<: (( &temporary ))
-  baseCluster:
-    dns:
-      ingressDomain: (( configValues.seed.ingressdomain ))
-  default:
-    dns:
-      provider:
-        type: (( configValues.dns.type ))
-        secretRef:
-          name: (( configValues.secretname "-ingress-dns-secret" ))
-          namespace: (( configValues.namespace ))
-    ingress:
-      domain: (( configValues.seed.ingressdomain ))
-      controller:
-        kind: nginx
 
 seedSettingMergeTemplate:
   <<: (( &template &temporary ))
@@ -272,6 +262,7 @@ pluginSpecs:
   seedReady:
     kubeconfig: (( configValues.kubeconfigs.virtual ))
     seed: (( configValues.name ))
+    timeout: 600
   deleteSeed:
     kubeconfig: (( configValues.kubeconfigs.virtual ))
     step: delete

--- a/components/kube-apiserver/chart/templates/poddisruptionbudget-kube-apiserver.yaml
+++ b/components/kube-apiserver/chart/templates/poddisruptionbudget-kube-apiserver.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: garden-kube-apiserver

--- a/components/network-policies/manifests/to-terminal-controller-manager.yaml
+++ b/components/network-policies/manifests/to-terminal-controller-manager.yaml
@@ -10,10 +10,10 @@ spec:
   - to:
     - namespaceSelector:
         matchLabels:
-          component: terminal-manager
+          app.kubernetes.io/name: terminal
       podSelector:
         matchLabels:
-          component: terminal-manager
+          app.kubernetes.io/name: terminal
   podSelector:
     matchLabels:
       networking.gardener.cloud/to-terminal-controller-manager: allowed

--- a/components/terminals/component.yaml
+++ b/components/terminals/component.yaml
@@ -19,4 +19,4 @@ component:
 git:
   <<: (( .landscape.versions.terminal-controller-manager ))
   files:
-    - config
+    - charts

--- a/components/terminals/deployment.yaml
+++ b/components/terminals/deployment.yaml
@@ -6,128 +6,91 @@ env: (( &temporary ))
 
 plugins:
   - pinned:
-    - kustomize: kustomize.virtual.render
-    - kubectl: kustomize.virtual.apply
+    - helm:
+      - terminals.virtual
+      - template
+    - kubectl: terminals.virtual
   - pinned:
-    - kubectl: kubectl_sa # create serviceaccount and clusterrole
-    - create_kubeconfig_secret: kcfg_admin # create secret manifest for admin kubeconfig
-    - create_kubeconfig_secret: kcfg_sa # create secret manifest for sa kubeconfig (directly overrides checked-out charts)
-    - kubectl: kubectl_admin_kubeconfig # apply admin kubeconfig secret
-  - pinned:
-    - kustomize-edit: kustomize.runtime.edit-tcm-image
-    - (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? { "kustomize-edit" = "kustomize.runtime.edit-rbac-image" } :~~ ))
-    - kustomize: kustomize.runtime.render
-    - kubectl: kustomize.runtime.apply
+    - helm:
+      - terminals.runtime
+      - template
+    - kubectl: terminals.runtime
 
-kcfg_admin:
-  name: (( settings.kubeconfig_secret_name ))
-  namespace: (( .landscape.namespace ))
-  kubeconfig_path: (( .settings.kubeconfig_path ))
-
-kcfg_sa:
-  name: kubeconfig
-  namespace: terminal-system
-  kubeconfig_path: (( .settings.kubeconfig_secret_path_sa ))
-  write_to: (( .settings.repo_path "/config/overlay/multi-cluster/runtime/manager/kubeconfig-secret.yaml" ))
-  server: (( .imports.kube-apiserver.export.apiserver_url_internal ))
-
-kubectl_sa:
-  kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
-  manifests:
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: terminal-controller-manager
-        namespace: terminal-system
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        name: dashboard.gardener.cloud:system:project-member
-        labels:
-          rbac.gardener.cloud/aggregate-to-project-member: "true"
-      rules:
-      - apiGroups:
-        - dashboard.gardener.cloud
-        resources:
-        - terminals
-        verbs:
-        - create
-        - delete
-        - deletecollection
-        - get
-        - list
-        - patch
-        - update
-        - watch
-
-kubectl_admin_kubeconfig:
-  kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
-  files:
-    - (( .settings.kubeconfig_secret_path_admin ))
-
-kustomize:
+terminals:
+  common:
+    values:
+      global:
+        admission:
+          config:
+            server:
+              webhooks:
+                caBundle: (( .state.ca.value.cert ))
+                tls:
+                  crt: (( .state.cert.value.cert ))
+                  key: (( .state.cert.value.key ))
+        controller:
+          serviceAccountName: terminal-controller-manager
+          manager:
+            image:
+              repository: (( .landscape.versions.terminal-controller-manager.image_repo || ~~ ))
+              tag: (( .landscape.versions.terminal-controller-manager.image_tag || ~~ ))
+              pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
+            kubeconfig: (( asyaml(.imports.kube-apiserver.export.kubeconfig) ))
+          kubeRBACProxy:
+            image:
+              repository: (( .landscape.versions.terminal-kube-rbac-proxy.image_repo || ~~ ))
+              tag: (( .landscape.versions.terminal-kube-rbac-proxy.image_tag || ~~ ))
+              pullPolicy: (( defined( tag ) -and tag != "latest" ? "IfNotPresent" :"Always" ))
+            kubeconfig: (( asyaml(.kube-rbac-proxy.kubeconfig) ))
+        deployment:
+          virtualGarden:
+            enabled: true
+          createNamespace: true
+          createCRD: true
   virtual:
-    render:
-      path: (( .settings.repo_path ))
-      kustomization: "config/overlay/multi-cluster/virtual-garden"
-    apply:
-      kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
-      files:
-        - (( env.GENDIR "/kustomize.virtual.render/manifest.yaml" ))
+    kubeconfig: (( .imports.kube-apiserver.export.kubeconfig ))
+    files:
+      - "terminals.virtual/rendered_charts.yaml"
+    source: "git/repo/charts/terminal/charts/application"
+    name: "terminals"
+    namespace: (( .settings.namespace ))
+    values: (( common.values ))
   runtime:
-    edit-tcm-image:
-      path: (( .settings.repo_path ))
-      kustomization: "config/manager"
-      args:
-        - set
-        - image
-        - (( "controller=" .landscape.versions.terminal-controller-manager.image_repo ":" ( .landscape.versions.terminal-controller-manager.image_tag || "latest" ) ))
-    edit-rbac-image:
-      path: (( env.GENDIR "/kustomize.runtime.edit-tcm-image/edit" ))
-      kustomization: "config/default"
-      args:
-        - set
-        - image
-        - (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? ( "quay.io/brancz/kube-rbac-proxy=" .landscape.versions.terminal-kube-rbac-proxy.image_repo ":" ( .landscape.versions.terminal-kube-rbac-proxy.image_tag || "latest" ) ) :~~ ))
-    render:
-      path: (( valid( .landscape.versions.terminal-kube-rbac-proxy.image_repo ) ? env.GENDIR "/kustomize.runtime.edit-rbac-image/edit" :env.GENDIR "/kustomize.runtime.edit-tcm-image/edit" ))
-      kustomization: "config/overlay/multi-cluster/runtime"
-    apply:
-      kubeconfig: (( .landscape.clusters[0].kubeconfig ))
-      files:
-        - (( env.GENDIR "/kustomize.runtime.render/manifest.yaml" ))
+    kubeconfig: (( landscape.clusters.[0].kubeconfig ))
+    files:
+      - "terminals.runtime/rendered_charts.yaml"
+    source: "git/repo/charts/terminal/charts/runtime"
+    name: "terminals"
+    namespace: (( .settings.namespace ))
+    values: (( common.values ))
+
+kube-rbac-proxy:
+  template:
+    <<: (( &template(merge) ))
+    users:
+    - name: (( stub() ))
+      user:
+        tokenfile: "/var/run/secrets/projected/serviceaccount/token"
+  kubeconfig: (( merge(template, read(lookup_file(landscape.clusters.[0].kubeconfig, env.ROOTDIR).[0], "yaml")) ))
 
 settings:
   namespace: terminal-system                                                                              # terminal controller manager namespace
-  kubeconfig_secret_name: garden-kubeconfig-for-admin                                                     # name of admin kubeconfig secret
-  kubeconfig_path: (( env.GENDIR "/" kubeconfig_secret_name ".kubeconfig" ))                              # path to admin kubeconfig
-  kubeconfig_secret_path_sa: (( env.GENDIR "/kubectl_sa/sa_terminal-controller-manager.kubeconfig" ))     # path to secret manifest for sa kubeconfig
-  kubeconfig_secret_path_admin: (( env.GENDIR "/kcfg_admin/secret_" kubeconfig_secret_name ".yaml" ))     # path to secret manifest for admin kubeconfig
-  repo_path: (( env.GENDIR "/git/repo" ))                                                                 # path to checked-out git repo for easy access
-  cert_path: (( repo_path "/config/secret/tls" ))                                                         # path to tls folder in checked-out git repo
-
-writefiles:
-  <<: (( &temporary ))
-  admin_kubeconfig: (( write( .settings.kubeconfig_path, .imports.kube-apiserver.export.kubeconfig ) )) # 'copy' admin kubeconfig to GENDIR
-  cert:
-    crt: (( write( .settings.cert_path "/terminal-controller-manager-tls.pem", .state.cert.value.cert ) ))
-    key: (( write( .settings.cert_path "/terminal-controller-manager-tls-key.pem", .state.cert.value.key ) ))
 
 spec:
   <<: (( &temporary ))
   cert:
-    commonName: "terminal-webhook-service.terminal-system.svc.cluster.local"
+    commonName: "terminal-admission-controller.terminal-system.svc.cluster.local"
     validity: 87600
     usage:
       - ServerAuth
       - ClientAuth
       - KeyEncipherment
     hosts:
-      - "terminal-webhook-service"
-      - "terminal-webhook-service.terminal-system"
-      - "terminal-webhook-service.terminal-system.svc"
-      - "terminal-webhook-service.terminal-system.svc.cluster"
-      - "terminal-webhook-service.terminal-system.svc.cluster.local"
+      - "terminal-admission-controller"
+      - "terminal-admission-controller.terminal-system"
+      - "terminal-admission-controller.terminal-system.svc"
+      - "terminal-admission-controller.terminal-system.svc.cluster"
+      - "terminal-admission-controller.terminal-system.svc.cluster.local"
 
 state:
   <<: (( &state(merge none) ))

--- a/components/terminals/export.yaml
+++ b/components/terminals/export.yaml
@@ -1,4 +1,4 @@
 ---
 settings: (( &temporary ))
 export:
-  kubeconfig_secret: (( settings.kubeconfig_secret_name ))
+  kubeconfig_secret: TODO

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -28,7 +28,7 @@
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",
-          "version": "v1.42.0"
+          "version": "v1.42.1"
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -52,7 +52,7 @@
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",
-          "version": "v1.30.0"
+          "version": "v1.31.1"
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -3,7 +3,7 @@
     "gardener": {
       "core": {
         "repo": "https://github.com/gardener/gardener.git",
-        "version": "v1.65.2"
+        "version": "v1.66.2"
       },
       "extensions": {
         "networking-calico": {

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -76,7 +76,7 @@
       "terminals": {
         "terminal-controller-manager": {
           "repo": "https://github.com/gardener/terminal-controller-manager.git",
-          "version": "v0.24.0"
+          "version": "v0.25.0"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -24,7 +24,7 @@
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",
-          "version": "v0.17.0"
+          "version": "v0.19.0"
         },
         "provider-aws": {
           "repo": "https://github.com/gardener/gardener-extension-provider-aws.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -36,7 +36,7 @@
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",
-          "version": "v1.28.0"
+          "version": "v1.28.1"
         },
         "provider-alicloud": {
           "repo": "https://github.com/gardener/gardener-extension-provider-alicloud.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -8,7 +8,7 @@
       "extensions": {
         "networking-calico": {
           "repo": "https://github.com/gardener/gardener-extension-networking-calico.git",
-          "version": "v1.31.0"
+          "version": "v1.31.2"
         },
         "os-coreos": {
           "repo": "https://github.com/gardener/gardener-extension-os-coreos.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -60,7 +60,7 @@
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",
-          "version": "v0.9.0"
+          "version": "v0.9.1"
         }
       }
     },

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -56,7 +56,7 @@
         },
         "provider-vsphere": {
           "repo": "https://github.com/gardener/gardener-extension-provider-vsphere.git",
-          "version": "v0.25.0"
+          "version": "v0.26.0"
         },
         "runtime-gvisor": {
           "repo": "https://github.com/gardener/gardener-extension-runtime-gvisor.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -44,7 +44,7 @@
         },
         "provider-openstack": {
           "repo": "https://github.com/gardener/gardener-extension-provider-openstack.git",
-          "version": "v1.32.0"
+          "version": "v1.32.1"
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -16,7 +16,7 @@
         },
         "os-suse-chost": {
           "repo": "https://github.com/gardener/gardener-extension-os-suse-chost.git",
-          "version": "v1.20.0"
+          "version": "v1.21.0"
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -48,7 +48,7 @@
         },
         "shoot-cert-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-cert-service.git",
-          "version": "v1.29.0"
+          "version": "v1.30.1"
         },
         "shoot-dns-service": {
           "repo": "https://github.com/gardener/gardener-extension-shoot-dns-service.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -20,7 +20,7 @@
         },
         "os-ubuntu": {
           "repo": "https://github.com/gardener/gardener-extension-os-ubuntu.git",
-          "version": "v1.20.0"
+          "version": "v1.21.0"
         },
         "os-gardenlinux": {
           "repo": "https://github.com/gardener/gardener-extension-os-gardenlinux.git",

--- a/dependency-versions.yaml
+++ b/dependency-versions.yaml
@@ -32,7 +32,7 @@
         },
         "provider-azure": {
           "repo": "https://github.com/gardener/gardener-extension-provider-azure.git",
-          "version": "v1.34.0"
+          "version": "v1.34.1"
         },
         "provider-gcp": {
           "repo": "https://github.com/gardener/gardener-extension-provider-gcp.git",


### PR DESCRIPTION
***Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Upgrade Gardener to `v1.66.2`
```
```other operator
Upgrade Gardener terminal-controller-manager to `v0.25.0`
```
```other operator
Upgrade Gardener extension provider-vsphere to `v0.26.0`
```
```other operator
Upgrade Gardener extension shoot-cert-service to `v1.30.1`
```
```other operator
Upgrade Gardener extension shoot-dns-service to `v1.31.1`
```
```other operator
Upgrade Gardener extension provider-azure to `v1.34.1`
```
```other operator
Upgrade Gardener extension runtime-gvisor to `v0.9.1`
```
```other operator
Upgrade Gardener extension provider-gcp to `v1.28.1`
```
```other operator
Upgrade Gardener extension provider-aws to `v1.42.1`
```
```other operator
Upgrade Gardener extension provider-openstack to `v1.32.1`
```
```other operator
Upgrade Gardener extension networking-calico to `v1.31.2`
```
```other operator
Upgrade Gardener extension os-gardenlinux to `v0.19.0`
```
```other operator
Upgrade Gardener extension os-suse-chost to `v1.21.0`
```
```other operator
Upgrade Gardener extension os-ubuntu to `v1.21.0`
```
```breaking operator
The `PodDisruptionBudget` resource in the virtual apiserver chart has been upgraded to `v1`. This might cause problems with old k8s versions.
```
```breaking operator
⚠️ The installation method for the terminal-controller-manager has changed significantly. Deploying over an existing landscape where the `terminals` component is active (it's deactivated by default) with this new version will most likely not work. For upgrading an existing landscape with active `terminals`, it's recommended to first remove the component (`sow delete -a terminals` (WARNING: this will also remove the `dashboard` component)), then upgrade to this version of garden-setup and then deploy it again.
```
