### PR TITLE
fix trailing plus problem on k8sversion

### DIFF
--- a/components/k8sversion/deployment.yaml
+++ b/components/k8sversion/deployment.yaml
@@ -16,9 +16,12 @@
 landscape: (( &temporary ))
 env: (( &temporary ))
 
+funcs:
+  remove_trailing_plus: (( |x|-> substr(x, -1) == "+" ? substr(x, 0, -1) :x ))
+
 commands:
   <<: (( &temporary ))
-  get_k8s_version: (( |kcfg_path|-> ("raw_version" = .commands.get_raw_version(kcfg_path)) raw_version.serverVersion.major "." raw_version.serverVersion.minor ))
+  get_k8s_version: (( |kcfg_path|-> ("raw_version" = .commands.get_raw_version(kcfg_path)) raw_version.serverVersion.major "." .funcs.remove_trailing_plus(raw_version.serverVersion.minor) ))
   get_raw_version: (( |kcfg_path|-> exec(["kubectl", "--kubeconfig", kcfg_path, "version", "-o", "yaml"]) ))
 
 iaasSeedsSoils: (( &temporary ( select[.landscape.iaas|elem|-> elem.mode == "seed" -or elem.mode == "soil"] ) ))


### PR DESCRIPTION
**Which issue(s) this PR fixes**: #1197 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Apparently, `kubectl version` returned a minor version with a `+` suffix for some k8s implementations, which garden-setup couldn't handle. The `k8sversion` component, which fetches the cluster versions, now removes this suffix, if it exists.
```
