### PR TITLE
cert-manager URL validation fix / EAB enabled

### DIFF
--- a/acre.yaml
+++ b/acre.yaml
@@ -802,6 +802,13 @@ validation:
           - - optionalfield
             - ca
             - ["and", [(( cert-manager_validators.selfsigned )), (( landscape.cert-manager.server.url ))], [(( cert-manager_validators.acme )), (( landscape.cert-manager.server.url ))]]
+          - - optionalfield
+            - eab
+            - - and
+              - - mapfield
+                - keyID
+              - - mapfield
+                - keySecret
       - - optionalfield
         - privateKey
         - privatekey

--- a/acre.yaml
+++ b/acre.yaml
@@ -798,7 +798,7 @@ validation:
             - url
             - - or
               - ["valueset", ["self-signed", "staging", "live"]]
-              - dnsdomain
+              - ["match", '(https:\/\/)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/[a-zA-Z0-9]+)*(\/)?']
           - - optionalfield
             - ca
             - ["and", [(( cert-manager_validators.selfsigned )), (( landscape.cert-manager.server.url ))], [(( cert-manager_validators.acme )), (( landscape.cert-manager.server.url ))]]

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -8,6 +8,7 @@ settings:
   self-signed: (( .caSpec.url == "self-signed" ))
   issuerName: (( .settings.self-signed ? "ca-issuer" :"acme-issuer" ))
   issuerPrivateKey: (( .settings.self-signed -or (! valid( .landscape.cert-manager.privateKey ) ) ? ~ :.landscape.cert-manager.privateKey ))
+  issuerEABSecretName: "acme-issuer-eab"
   caSecret: "self-signed-ca"
   certClass: "garden-setup"
   ca:
@@ -20,6 +21,7 @@ caSpec:
   instantiateIfNeeded: (( |x|-> type( x ) == "template" ? *x :x ))
   server: (( caSpec.instantiateIfNeeded( .servers[.landscape.cert-manager.server.url] || .landscape.cert-manager.server ) ))
   url: (( server.url || server ))
+  eab: (( server.eab || ~~ ))
   ca: (( server.ca || ~~ ))
 
 plugins:
@@ -54,11 +56,29 @@ issuer-secret:
     data:
       privateKey: (( base64(settings.issuerPrivateKey) ))
 
+eab:
+  <<: (( &template &temporary ))
+  issuerSnippet:
+    keyID: (( .caSpec.eab.keyID ))
+    keySecretRef:
+      name: (( .settings.issuerEABSecretName ))
+      namespace: (( .settings.namespace ))
+  manifests:
+  - apiVersion: v1
+    kind: Secret
+    type: Opaque
+    metadata:
+      name: (( .settings.issuerEABSecretName ))
+      namespace: (( .settings.namespace ))
+    data:
+      hmacKey: (( base64(.caSpec.eab.keySecret) ))
+
 acme_issuer:
   <<: (( &template &temporary ))
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   manifests:
     - <<: (( valid( .settings.issuerPrivateKey ) ? *issuer-secret :~ ))
+    - <<: (( valid( .caSpec.eab ) ? *eab.manifests :~ ))
     - apiVersion: cert.gardener.cloud/v1alpha1
       kind: Issuer
       metadata:
@@ -72,6 +92,7 @@ acme_issuer:
           privateKeySecretRef:
             name: (( .settings.issuerName "-secret" ))
             namespace: (( .settings.namespace ))
+          externalAccountBinding: (( valid( .caSpec.eab ) ? *eab.issuerSnippet :~~ ))
 
 ca_issuer:
   <<: (( &template &temporary ))

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -21,7 +21,7 @@ caSpec:
   instantiateIfNeeded: (( |x|-> type( x ) == "template" ? *x :x ))
   server: (( caSpec.instantiateIfNeeded( .servers[.landscape.cert-manager.server.url] || .landscape.cert-manager.server ) ))
   url: (( server.url || server ))
-  eab: (( server.eab || ~~ ))
+  eab: (( .landscape.cert-manager.server.eab || ~~ ))
   ca: (( server.ca || ~~ ))
 
 plugins:
@@ -57,13 +57,15 @@ issuer-secret:
       privateKey: (( base64(settings.issuerPrivateKey) ))
 
 eab:
-  <<: (( &template &temporary ))
+  <<: (( &temporary ))
   issuerSnippet:
+    <<: (( &template ))
     keyID: (( .caSpec.eab.keyID ))
     keySecretRef:
       name: (( .settings.issuerEABSecretName ))
       namespace: (( .settings.namespace ))
   manifests:
+  - <<: (( &template ))
   - apiVersion: v1
     kind: Secret
     type: Opaque
@@ -92,7 +94,7 @@ acme_issuer:
           privateKeySecretRef:
             name: (( .settings.issuerName "-secret" ))
             namespace: (( .settings.namespace ))
-          externalAccountBinding: (( valid( .caSpec.eab ) ? *eab.issuerSnippet :~~ ))
+          externalAccountBinding: (( valid( .caSpec.eab ) ? *.eab.issuerSnippet :~~ ))
 
 ca_issuer:
   <<: (( &template &temporary ))

--- a/components/cert-manager/controller/deployment.yaml
+++ b/components/cert-manager/controller/deployment.yaml
@@ -78,7 +78,7 @@ acme_issuer:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))
   manifests:
     - <<: (( valid( .settings.issuerPrivateKey ) ? *issuer-secret :~ ))
-    - <<: (( valid( .caSpec.eab ) ? *eab.manifests :~ ))
+    - <<: (( valid( .caSpec.eab ) ? *.eab.manifests :~ ))
     - apiVersion: cert.gardener.cloud/v1alpha1
       kind: Issuer
       metadata:

--- a/docs/extended/cert-manager.md
+++ b/docs/extended/cert-manager.md
@@ -16,6 +16,9 @@ Internally, if `landscape.cert-manager.server` is a string, it is converted into
       ca:
         crt:
         key:
+      eab:
+        keyID:
+        keySecret:
 ```
 
 It is also possible to use this structure directly in the `acre.yaml` file, with the following effects:
@@ -26,3 +29,5 @@ If `url` is `self-signed` and `ca.crt` and `ca.key` contain a CA certificate and
 If `url` points to an ACME server that produces untrusted certificates (as the letsencrypt staging server, for example), *the root CA and all intermediate CAs that are used by that ACME server to sign certificates* have to be given in `ca.crt` (simply appended to each other). Otherwise, the deployed kube-apiserver won't be able to verify the dashboard certificate and thus won't accept it. There is one exception to this - if `server.url` is set to `staging`, the required letsencrypt certificates (root CA and intermediate CA) are automatically downloaded and do not have to be provided.
 
 If `url` is `live` or points to an ACME server generating publicly trusted certificates, the `ca` node must not be there at all. You can just use the simplified notation and put the acme server URL directly into `landscape.cert-manager.server`.
+
+If your ACME server requires you to specify an EAB, you have to use the extended notation and specify its id and secret as shown above.


### PR DESCRIPTION
**What this PR does / why we need it**:
- fixes too strict validation of the ACME server URL
- enables specifying an EAB for the ACME issuer

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The validation of the ACME server URL was too strict and has been fixed.
```
```feature operator
It is now possible to specify an EAB for the ACME issuer.
```
